### PR TITLE
feat: Add diagnostic tools for heap, memory, crash analysis and remote support

### DIFF
--- a/src/Atlas.Server/Tools/CrashDiagnosticTools.cs
+++ b/src/Atlas.Server/Tools/CrashDiagnosticTools.cs
@@ -1,0 +1,546 @@
+using Microsoft.Diagnostics.Runtime;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Text;
+
+namespace Atlas.Server.Tools;
+
+[McpServerToolType]
+public static class CrashDiagnosticTools
+{
+    [McpServerTool(Name = "analyze_crash")]
+    [Description("Auto-detect crash cause - identifies faulting thread, exception chain, and probable cause (like WinDbg !analyze -v)")]
+    public static object AnalyzeCrash(
+        [Description("Full path to the .dmp file")] string filePath)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+
+            // Find threads with exceptions
+            var threadsWithExceptions = runtime.Threads
+                .Where(t => t.CurrentException != null)
+                .ToList();
+
+            ClrThread? faultingThread = null;
+            ClrException? primaryException = null;
+
+            // Find the most likely faulting thread
+            foreach (var thread in threadsWithExceptions)
+            {
+                var ex = thread.CurrentException;
+                if (ex != null)
+                {
+                    // Prefer threads with unhandled/fatal exceptions
+                    if (primaryException == null ||
+                        ex.Type?.Name?.Contains("StackOverflow") == true ||
+                        ex.Type?.Name?.Contains("OutOfMemory") == true ||
+                        ex.Type?.Name?.Contains("AccessViolation") == true)
+                    {
+                        faultingThread = thread;
+                        primaryException = ex;
+                    }
+                }
+            }
+
+            // If no exception found, look for threads in problematic states
+            if (faultingThread == null)
+            {
+                faultingThread = runtime.Threads.FirstOrDefault(t =>
+                    t.EnumerateStackTrace().Any(f =>
+                        f.Method?.Name?.Contains("Throw") == true ||
+                        f.Method?.Name?.Contains("FailFast") == true));
+            }
+
+            object? crashAnalysis = null;
+            if (faultingThread != null && primaryException != null)
+            {
+                var exceptionChain = GetExceptionChain(primaryException);
+                var stackTrace = faultingThread.EnumerateStackTrace()
+                    .Take(20)
+                    .Select(f => new
+                    {
+                        method = f.Method?.ToString() ?? "<unknown>",
+                        module = f.Method?.Type?.Module?.Name,
+                        offset = f.InstructionPointer > 0 ? $"0x{f.InstructionPointer:X}" : null
+                    })
+                    .ToList();
+
+                crashAnalysis = new
+                {
+                    faultingThread = new
+                    {
+                        osThreadId = $"0x{faultingThread.OSThreadId:X}",
+                        managedThreadId = faultingThread.ManagedThreadId,
+                        isGc = faultingThread.IsGc,
+                        isFinalizer = faultingThread.IsFinalizer
+                    },
+                    exception = new
+                    {
+                        type = primaryException.Type?.Name,
+                        message = primaryException.Message,
+                        hresult = $"0x{primaryException.HResult:X8}"
+                    },
+                    exceptionChain,
+                    stackTrace,
+                    probableCause = InferProbableCause(primaryException)
+                };
+            }
+
+            // Summary of all threads
+            var threadSummary = runtime.Threads
+                .Select(t => new
+                {
+                    osThreadId = $"0x{t.OSThreadId:X}",
+                    managedThreadId = t.ManagedThreadId,
+                    hasException = t.CurrentException != null,
+                    exceptionType = t.CurrentException?.Type?.Name,
+                    isGc = t.IsGc,
+                    isFinalizer = t.IsFinalizer,
+                    stackDepth = t.EnumerateStackTrace().Count()
+                })
+                .Where(t => t.hasException || t.stackDepth > 0)
+                .Take(20)
+                .ToList();
+
+            return new
+            {
+                status = crashAnalysis != null ? "crash_detected" : "no_crash_detected",
+                crashAnalysis,
+                threadCount = runtime.Threads.Count(),
+                threadsWithExceptions = threadsWithExceptions.Count,
+                threadSummary
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "dump_exception")]
+    [Description("Print exception details with full inner exception chain (like WinDbg !pe)")]
+    public static object DumpException(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Optional: thread OS ID (hex) to get exception from. If not specified, finds first thread with exception")] string? threadId = null)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+
+            ClrThread? targetThread = null;
+
+            if (!string.IsNullOrEmpty(threadId))
+            {
+                var tid = ParseThreadId(threadId);
+                targetThread = runtime.Threads.FirstOrDefault(t => t.OSThreadId == tid);
+                if (targetThread == null)
+                    return new { error = $"Thread {threadId} not found" };
+            }
+            else
+            {
+                targetThread = runtime.Threads.FirstOrDefault(t => t.CurrentException != null);
+            }
+
+            if (targetThread == null)
+                return new { error = "No thread with exception found" };
+
+            var exception = targetThread.CurrentException;
+            if (exception == null)
+                return new { error = $"Thread 0x{targetThread.OSThreadId:X} has no current exception" };
+
+            var exceptionChain = GetExceptionChain(exception);
+
+            return new
+            {
+                thread = new
+                {
+                    osThreadId = $"0x{targetThread.OSThreadId:X}",
+                    managedThreadId = targetThread.ManagedThreadId
+                },
+                exceptionCount = exceptionChain.Count,
+                exceptions = exceptionChain
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "dump_stack")]
+    [Description("Get detailed stack trace with method signatures (like WinDbg !clrstack)")]
+    public static object DumpStack(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Thread OS ID (hex like 0x1A4C). If not specified, dumps all threads")] string? threadId = null,
+        [Description("Max frames per thread (default 50)")] int maxFrames = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+
+            IEnumerable<ClrThread> threads;
+            if (!string.IsNullOrEmpty(threadId))
+            {
+                var tid = ParseThreadId(threadId);
+                var thread = runtime.Threads.FirstOrDefault(t => t.OSThreadId == tid);
+                if (thread == null)
+                    return new { error = $"Thread {threadId} not found" };
+                threads = new[] { thread };
+            }
+            else
+            {
+                threads = runtime.Threads.Where(t => t.EnumerateStackTrace().Any()).Take(20);
+            }
+
+            var stacks = threads.Select(t =>
+            {
+                var frames = t.EnumerateStackTrace()
+                    .Take(maxFrames)
+                    .Select(f =>
+                    {
+                        var method = f.Method;
+                        string signature = method?.Signature ?? method?.ToString() ?? "<unknown>";
+
+                        return new
+                        {
+                            instructionPointer = $"0x{f.InstructionPointer:X}",
+                            stackPointer = $"0x{f.StackPointer:X}",
+                            signature,
+                            module = method?.Type?.Module?.Name
+                        };
+                    })
+                    .ToList();
+
+                return new
+                {
+                    osThreadId = $"0x{t.OSThreadId:X}",
+                    managedThreadId = t.ManagedThreadId,
+                    isGc = t.IsGc,
+                    isFinalizer = t.IsFinalizer,
+                    hasException = t.CurrentException != null,
+                    exceptionType = t.CurrentException?.Type?.Name,
+                    frameCount = frames.Count,
+                    frames
+                };
+            }).ToList();
+
+            return new
+            {
+                threadCount = stacks.Count,
+                stacks
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "detect_deadlocks")]
+    [Description("Analyze threads for potential deadlock patterns based on lock wait states")]
+    public static object DetectDeadlocks(
+        [Description("Full path to the .dmp file")] string filePath)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+
+            // Analyze threads for lock-related patterns in their stacks
+            var lockWaitingThreads = new List<object>();
+
+            foreach (var thread in runtime.Threads)
+            {
+                var stackFrames = thread.EnumerateStackTrace().ToList();
+                var isWaitingOnLock = false;
+                string? waitMethod = null;
+
+                foreach (var frame in stackFrames)
+                {
+                    var methodName = frame.Method?.Name ?? "";
+                    var typeName = frame.Method?.Type?.Name ?? "";
+
+                    // Check for common lock wait patterns
+                    if (methodName.Contains("Wait") ||
+                        methodName.Contains("Enter") ||
+                        typeName.Contains("Monitor") ||
+                        typeName.Contains("Mutex") ||
+                        typeName.Contains("Semaphore") ||
+                        typeName.Contains("ReaderWriterLock") ||
+                        typeName.Contains("ManualResetEvent") ||
+                        typeName.Contains("AutoResetEvent"))
+                    {
+                        isWaitingOnLock = true;
+                        waitMethod = $"{typeName}.{methodName}";
+                        break;
+                    }
+                }
+
+                if (isWaitingOnLock)
+                {
+                    lockWaitingThreads.Add(new
+                    {
+                        osThreadId = $"0x{thread.OSThreadId:X}",
+                        managedThreadId = thread.ManagedThreadId,
+                        waitMethod,
+                        topFrames = stackFrames.Take(5).Select(f => f.Method?.ToString() ?? "<unknown>").ToList()
+                    });
+                }
+            }
+
+            return new
+            {
+                potentialDeadlock = lockWaitingThreads.Count > 1,
+                waitingThreadCount = lockWaitingThreads.Count,
+                waitingThreads = lockWaitingThreads,
+                analysis = lockWaitingThreads.Count > 1
+                    ? "Multiple threads waiting on locks detected. Review thread stacks for circular wait patterns."
+                    : lockWaitingThreads.Count == 1
+                        ? "One thread waiting on a lock. May be waiting for external resource."
+                        : "No threads waiting on locks detected.",
+                note = "For detailed deadlock analysis, examine the thread stacks for circular dependencies."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "waiting_threads")]
+    [Description("Show what each thread is waiting on based on stack analysis")]
+    public static object WaitingThreads(
+        [Description("Full path to the .dmp file")] string filePath)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+
+            var threads = runtime.Threads
+                .Select(t =>
+                {
+                    var stackFrames = t.EnumerateStackTrace().ToList();
+                    var topFrame = stackFrames.FirstOrDefault();
+
+                    // Infer wait state from stack
+                    string waitState = "Unknown";
+                    string? waitingOn = null;
+
+                    foreach (var frame in stackFrames.Take(10))
+                    {
+                        var methodName = frame.Method?.Name ?? "";
+                        var typeName = frame.Method?.Type?.Name ?? "";
+                        var fullName = $"{typeName}.{methodName}";
+
+                        if (typeName.Contains("Monitor") || methodName == "Enter" || methodName == "TryEnter")
+                        {
+                            waitState = "WaitingOnMonitor";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (typeName.Contains("Mutex"))
+                        {
+                            waitState = "WaitingOnMutex";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (typeName.Contains("Semaphore"))
+                        {
+                            waitState = "WaitingOnSemaphore";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (typeName.Contains("ManualResetEvent") || typeName.Contains("AutoResetEvent"))
+                        {
+                            waitState = "WaitingOnEvent";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (methodName.Contains("Sleep"))
+                        {
+                            waitState = "Sleeping";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (methodName.Contains("Wait") && !methodName.Contains("Await"))
+                        {
+                            waitState = "Waiting";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (methodName.Contains("Join"))
+                        {
+                            waitState = "WaitingForThread";
+                            waitingOn = fullName;
+                            break;
+                        }
+                        if (typeName.Contains("Socket") || typeName.Contains("Stream"))
+                        {
+                            if (methodName.Contains("Read") || methodName.Contains("Receive"))
+                            {
+                                waitState = "WaitingForIO";
+                                waitingOn = fullName;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (waitState == "Unknown" && stackFrames.Any())
+                    {
+                        waitState = "Running";
+                    }
+
+                    return new
+                    {
+                        osThreadId = $"0x{t.OSThreadId:X}",
+                        managedThreadId = t.ManagedThreadId,
+                        isGc = t.IsGc,
+                        isFinalizer = t.IsFinalizer,
+                        isAlive = t.IsAlive,
+                        waitState,
+                        waitingOn,
+                        topFrame = topFrame?.Method?.ToString()
+                    };
+                })
+                .Where(t => t.isAlive)
+                .ToList();
+
+            var stateGroups = threads
+                .GroupBy(t => t.waitState)
+                .Select(g => new { state = g.Key, count = g.Count() })
+                .OrderByDescending(g => g.count)
+                .ToList();
+
+            return new
+            {
+                totalThreads = threads.Count,
+                stateBreakdown = stateGroups,
+                threads
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    private static List<object> GetExceptionChain(ClrException exception)
+    {
+        var chain = new List<object>();
+        var current = exception;
+        int depth = 0;
+
+        while (current != null && depth < 10)
+        {
+            var stackTrace = current.StackTrace
+                .Take(10)
+                .Select(f => f.Method?.ToString() ?? "<unknown>")
+                .ToList();
+
+            chain.Add(new
+            {
+                depth,
+                type = current.Type?.Name,
+                message = current.Message,
+                hresult = $"0x{current.HResult:X8}",
+                address = $"0x{current.Address:X}",
+                stackTrace
+            });
+
+            current = current.Inner;
+            depth++;
+        }
+
+        return chain;
+    }
+
+    private static string InferProbableCause(ClrException exception)
+    {
+        var exType = exception.Type?.Name ?? "";
+        var message = exception.Message ?? "";
+
+        if (exType.Contains("NullReferenceException"))
+            return "Null reference - an object was accessed before being initialized";
+
+        if (exType.Contains("StackOverflowException"))
+            return "Stack overflow - likely infinite recursion or too deep call stack";
+
+        if (exType.Contains("OutOfMemoryException"))
+            return "Out of memory - process exceeded available memory or had a memory leak";
+
+        if (exType.Contains("AccessViolationException"))
+            return "Access violation - invalid memory access, possibly from native interop";
+
+        if (exType.Contains("InvalidOperationException"))
+            return $"Invalid operation - {message}";
+
+        if (exType.Contains("ArgumentException") || exType.Contains("ArgumentNullException"))
+            return $"Invalid argument - {message}";
+
+        if (exType.Contains("IOException"))
+            return $"I/O error - {message}";
+
+        if (exType.Contains("TimeoutException"))
+            return "Operation timed out";
+
+        if (exType.Contains("SqlException") || exType.Contains("DbException"))
+            return $"Database error - {message}";
+
+        return $"Exception: {exType} - {message}";
+    }
+
+    private static uint ParseThreadId(string threadId)
+    {
+        var tid = threadId.Trim();
+        if (tid.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            tid = tid[2..];
+
+        if (uint.TryParse(tid, System.Globalization.NumberStyles.HexNumber, null, out var result))
+            return result;
+
+        if (uint.TryParse(threadId, out result))
+            return result;
+
+        return 0;
+    }
+}

--- a/src/Atlas.Server/Tools/HeapAnalysisTools.cs
+++ b/src/Atlas.Server/Tools/HeapAnalysisTools.cs
@@ -1,0 +1,439 @@
+using Microsoft.Diagnostics.Runtime;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace Atlas.Server.Tools;
+
+[McpServerToolType]
+public static class HeapAnalysisTools
+{
+    [McpServerTool(Name = "dump_heap_stats")]
+    [Description("Get object count and size statistics by type (like WinDbg !dumpheap -stat)")]
+    public static object DumpHeapStats(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Minimum object count to include in results (default 10)")] int minCount = 10,
+        [Description("Max types to return (default 50)")] int limit = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            var stats = new Dictionary<string, (long count, long size)>();
+            long totalObjects = 0;
+            long totalSize = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid) continue;
+
+                var typeName = obj.Type?.Name ?? "<unknown>";
+                var size = (long)obj.Size;
+
+                if (!stats.ContainsKey(typeName))
+                    stats[typeName] = (0, 0);
+
+                var current = stats[typeName];
+                stats[typeName] = (current.count + 1, current.size + size);
+                totalObjects++;
+                totalSize += size;
+            }
+
+            var typeStats = stats
+                .Where(s => s.Value.count >= minCount)
+                .OrderByDescending(s => s.Value.size)
+                .Take(limit)
+                .Select(s => new
+                {
+                    type = s.Key,
+                    count = s.Value.count,
+                    totalSizeBytes = s.Value.size,
+                    totalSizeMB = Math.Round(s.Value.size / 1024.0 / 1024.0, 2),
+                    avgSizeBytes = s.Value.count > 0 ? s.Value.size / s.Value.count : 0
+                })
+                .ToList();
+
+            return new
+            {
+                totalObjects,
+                totalSizeBytes = totalSize,
+                totalSizeMB = Math.Round(totalSize / 1024.0 / 1024.0, 2),
+                typeCount = stats.Count,
+                types = typeStats
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "find_objects")]
+    [Description("Find objects by type name (like WinDbg !dumpheap -type)")]
+    public static object FindObjects(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Type name to search for (partial match)")] string typeName,
+        [Description("Max objects to return (default 20)")] int limit = 20)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            var matches = new List<object>();
+            long totalMatches = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid) continue;
+
+                var objTypeName = obj.Type?.Name ?? "";
+                if (!objTypeName.Contains(typeName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                totalMatches++;
+
+                if (matches.Count < limit)
+                {
+                    matches.Add(new
+                    {
+                        address = $"0x{obj.Address:X}",
+                        type = objTypeName,
+                        size = obj.Size
+                    });
+                }
+            }
+
+            return new
+            {
+                query = typeName,
+                totalMatches,
+                returnedCount = matches.Count,
+                objects = matches
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Search failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "dump_object")]
+    [Description("Inspect object fields at a specific address (like WinDbg !do)")]
+    public static object DumpObject(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Object address (hex string like 0x00007ff8a1234567)")] string address)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            var objAddress = ParseAddress(address);
+            if (objAddress == 0)
+                return new { error = $"Invalid address format: {address}" };
+
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            var obj = heap.GetObject(objAddress);
+            if (!obj.IsValid)
+                return new { error = $"No valid object at address {address}" };
+
+            var type = obj.Type;
+            if (type == null)
+                return new { error = $"Could not determine type for object at {address}" };
+
+            var fields = new List<object>();
+            foreach (var field in type.Fields)
+            {
+                string fieldValueStr;
+
+                try
+                {
+                    if (field.IsObjectReference)
+                    {
+                        var refObj = obj.ReadObjectField(field.Name ?? "");
+                        if (refObj.IsNull)
+                            fieldValueStr = "null";
+                        else if (refObj.Type?.Name == "System.String")
+                            fieldValueStr = $"\"{refObj.AsString()}\"";
+                        else
+                            fieldValueStr = $"0x{refObj.Address:X} ({refObj.Type?.Name ?? "?"})";
+                    }
+                    else if (field.IsPrimitive)
+                    {
+                        // Read primitive field value based on type
+                        fieldValueStr = ReadPrimitiveField(obj, field);
+                    }
+                    else if (field.IsValueType)
+                    {
+                        fieldValueStr = $"[ValueType: {field.Type?.Name ?? "?"}]";
+                    }
+                    else
+                    {
+                        fieldValueStr = "<unknown>";
+                    }
+                }
+                catch
+                {
+                    fieldValueStr = "<error reading>";
+                }
+
+                fields.Add(new
+                {
+                    name = field.Name,
+                    type = field.Type?.Name ?? "?",
+                    offset = field.Offset,
+                    value = fieldValueStr
+                });
+            }
+
+            return new
+            {
+                address = $"0x{obj.Address:X}",
+                type = type.Name,
+                baseType = type.BaseType?.Name,
+                size = obj.Size,
+                isArray = type.IsArray,
+                arrayLength = type.IsArray ? obj.AsArray().Length : (int?)null,
+                fields
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Dump failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "find_strings")]
+    [Description("Find string objects, optionally containing specific text")]
+    public static object FindStrings(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Optional: text to search for within strings")] string? containing = null,
+        [Description("Minimum string length (default 10)")] int minLength = 10,
+        [Description("Max strings to return (default 50)")] int limit = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            var strings = new List<object>();
+            long totalStrings = 0;
+            long totalMatches = 0;
+            long totalStringSize = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid || obj.Type?.Name != "System.String") continue;
+
+                totalStrings++;
+                var str = obj.AsString();
+                if (str == null) continue;
+
+                totalStringSize += (long)obj.Size;
+
+                if (str.Length < minLength) continue;
+
+                if (!string.IsNullOrEmpty(containing) &&
+                    !str.Contains(containing, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                totalMatches++;
+
+                if (strings.Count < limit)
+                {
+                    strings.Add(new
+                    {
+                        address = $"0x{obj.Address:X}",
+                        length = str.Length,
+                        size = obj.Size,
+                        value = str.Length > 200 ? str[..200] + "..." : str
+                    });
+                }
+            }
+
+            return new
+            {
+                totalStrings,
+                totalStringsSizeMB = Math.Round(totalStringSize / 1024.0 / 1024.0, 2),
+                searchFilter = containing,
+                minLength,
+                matchCount = totalMatches,
+                returnedCount = strings.Count,
+                strings
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Search failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "gc_roots")]
+    [Description("Find GC roots keeping an object alive (like WinDbg !gcroot)")]
+    public static object GcRoots(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Object address (hex string like 0x00007ff8a1234567)")] string address)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            var objAddress = ParseAddress(address);
+            if (objAddress == 0)
+                return new { error = $"Invalid address format: {address}" };
+
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            var obj = heap.GetObject(objAddress);
+            if (!obj.IsValid)
+                return new { error = $"No valid object at address {address}" };
+
+            var roots = new List<object>();
+
+            // Find direct roots pointing to this object
+            foreach (var root in heap.EnumerateRoots())
+            {
+                if (root.Object == objAddress)
+                {
+                    roots.Add(new
+                    {
+                        rootKind = root.RootKind.ToString(),
+                        address = $"0x{root.Address:X}",
+                        objectAddress = $"0x{root.Object:X}",
+                        isPinned = root.IsPinned,
+                        isInterior = root.IsInterior
+                    });
+                }
+            }
+
+            // Find objects that reference this object
+            var referencingObjects = new List<object>();
+            foreach (var heapObj in heap.EnumerateObjects())
+            {
+                if (!heapObj.IsValid || heapObj.Type == null) continue;
+
+                foreach (var refObj in heapObj.EnumerateReferences())
+                {
+                    if (refObj.Address == objAddress)
+                    {
+                        referencingObjects.Add(new
+                        {
+                            address = $"0x{heapObj.Address:X}",
+                            type = heapObj.Type.Name
+                        });
+
+                        if (referencingObjects.Count >= 20) break;
+                    }
+                }
+                if (referencingObjects.Count >= 20) break;
+            }
+
+            return new
+            {
+                targetObject = new
+                {
+                    address = $"0x{obj.Address:X}",
+                    type = obj.Type?.Name ?? "<unknown>",
+                    size = obj.Size
+                },
+                directRootCount = roots.Count,
+                directRoots = roots,
+                referencingObjectCount = referencingObjects.Count,
+                referencingObjects,
+                note = "Use referencing objects to trace back to GC roots"
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Root analysis failed: {ex.Message}" };
+        }
+    }
+
+    private static string ReadPrimitiveField(ClrObject obj, ClrInstanceField field)
+    {
+        try
+        {
+            var typeName = field.Type?.Name ?? "";
+            return typeName switch
+            {
+                "System.Int32" => obj.ReadField<int>(field.Name ?? "").ToString(),
+                "System.Int64" => obj.ReadField<long>(field.Name ?? "").ToString(),
+                "System.Int16" => obj.ReadField<short>(field.Name ?? "").ToString(),
+                "System.Byte" => obj.ReadField<byte>(field.Name ?? "").ToString(),
+                "System.Boolean" => obj.ReadField<bool>(field.Name ?? "").ToString(),
+                "System.Double" => obj.ReadField<double>(field.Name ?? "").ToString(),
+                "System.Single" => obj.ReadField<float>(field.Name ?? "").ToString(),
+                "System.Char" => obj.ReadField<char>(field.Name ?? "").ToString(),
+                "System.UInt32" => obj.ReadField<uint>(field.Name ?? "").ToString(),
+                "System.UInt64" => obj.ReadField<ulong>(field.Name ?? "").ToString(),
+                "System.IntPtr" => $"0x{obj.ReadField<nint>(field.Name ?? ""):X}",
+                "System.UIntPtr" => $"0x{obj.ReadField<nuint>(field.Name ?? ""):X}",
+                _ => $"[{typeName}]"
+            };
+        }
+        catch
+        {
+            return "<error>";
+        }
+    }
+
+    private static ulong ParseAddress(string address)
+    {
+        var addr = address.Trim();
+        if (addr.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            addr = addr[2..];
+
+        if (ulong.TryParse(addr, System.Globalization.NumberStyles.HexNumber, null, out var result))
+            return result;
+
+        return 0;
+    }
+}

--- a/src/Atlas.Server/Tools/MemoryDiagnosticTools.cs
+++ b/src/Atlas.Server/Tools/MemoryDiagnosticTools.cs
@@ -1,0 +1,438 @@
+using Microsoft.Diagnostics.Runtime;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace Atlas.Server.Tools;
+
+[McpServerToolType]
+public static class MemoryDiagnosticTools
+{
+    [McpServerTool(Name = "compare_heaps")]
+    [Description("Compare two dump files to identify memory growth - shows types with largest count/size changes")]
+    public static object CompareHeaps(
+        [Description("Path to the baseline (earlier) dump file")] string baselinePath,
+        [Description("Path to the comparison (later) dump file")] string comparisonPath,
+        [Description("Minimum size delta in bytes to report (default 1MB)")] long minSizeDelta = 1024 * 1024,
+        [Description("Max types to return (default 30)")] int limit = 30)
+    {
+        if (!File.Exists(baselinePath))
+            return new { error = $"Baseline file not found: {baselinePath}" };
+        if (!File.Exists(comparisonPath))
+            return new { error = $"Comparison file not found: {comparisonPath}" };
+
+        try
+        {
+            var baselineStats = GetHeapStats(baselinePath);
+            var comparisonStats = GetHeapStats(comparisonPath);
+
+            if (baselineStats.error != null)
+                return new { error = $"Baseline analysis failed: {baselineStats.error}" };
+            if (comparisonStats.error != null)
+                return new { error = $"Comparison analysis failed: {comparisonStats.error}" };
+
+            var allTypes = baselineStats.stats.Keys.Union(comparisonStats.stats.Keys).ToList();
+
+            var deltas = allTypes
+                .Select(type =>
+                {
+                    baselineStats.stats.TryGetValue(type, out var baseline);
+                    comparisonStats.stats.TryGetValue(type, out var comparison);
+
+                    return new
+                    {
+                        type,
+                        baselineCount = baseline.count,
+                        comparisonCount = comparison.count,
+                        countDelta = comparison.count - baseline.count,
+                        baselineSizeBytes = baseline.size,
+                        comparisonSizeBytes = comparison.size,
+                        sizeDeltaBytes = comparison.size - baseline.size,
+                        sizeDeltaMB = Math.Round((comparison.size - baseline.size) / 1024.0 / 1024.0, 2)
+                    };
+                })
+                .Where(d => Math.Abs(d.sizeDeltaBytes) >= minSizeDelta)
+                .OrderByDescending(d => d.sizeDeltaBytes)
+                .Take(limit)
+                .ToList();
+
+            var totalBaseline = baselineStats.stats.Values.Sum(s => s.size);
+            var totalComparison = comparisonStats.stats.Values.Sum(s => s.size);
+
+            return new
+            {
+                baseline = new
+                {
+                    path = baselinePath,
+                    totalSizeMB = Math.Round(totalBaseline / 1024.0 / 1024.0, 2),
+                    typeCount = baselineStats.stats.Count
+                },
+                comparison = new
+                {
+                    path = comparisonPath,
+                    totalSizeMB = Math.Round(totalComparison / 1024.0 / 1024.0, 2),
+                    typeCount = comparisonStats.stats.Count
+                },
+                totalGrowthMB = Math.Round((totalComparison - totalBaseline) / 1024.0 / 1024.0, 2),
+                typesWithGrowth = deltas.Count(d => d.sizeDeltaBytes > 0),
+                typesWithShrinkage = deltas.Count(d => d.sizeDeltaBytes < 0),
+                deltas
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Comparison failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "large_objects")]
+    [Description("List objects on the Large Object Heap (>85KB) - common source of memory issues")]
+    public static object LargeObjects(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Max objects to return (default 50)")] int limit = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            var lohSegments = heap.Segments.Where(s => s.Kind == GCSegmentKind.Large).ToList();
+            var objects = new List<object>();
+            long totalLohSize = 0;
+            long totalLohCount = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid) continue;
+
+                // Check if object is in LOH
+                var segment = heap.GetSegmentByAddress(obj.Address);
+                if (segment == null || segment.Kind != GCSegmentKind.Large) continue;
+
+                totalLohCount++;
+                totalLohSize += (long)obj.Size;
+
+                if (objects.Count < limit)
+                {
+                    var typeName = obj.Type?.Name ?? "<unknown>";
+                    string preview = "";
+
+                    if (typeName == "System.String")
+                    {
+                        var str = obj.AsString();
+                        preview = str?.Length > 100 ? str[..100] + "..." : str ?? "";
+                    }
+                    else if (typeName.EndsWith("[]"))
+                    {
+                        preview = $"Length: {obj.AsArray().Length}";
+                    }
+
+                    objects.Add(new
+                    {
+                        address = $"0x{obj.Address:X}",
+                        type = typeName,
+                        sizeBytes = obj.Size,
+                        sizeMB = Math.Round((double)obj.Size / 1024 / 1024, 2),
+                        preview
+                    });
+                }
+            }
+
+            // Sort by size descending
+            objects = objects.OrderByDescending(o => ((dynamic)o).sizeBytes).ToList();
+
+            return new
+            {
+                lohSegmentCount = lohSegments.Count,
+                totalLohSizeMB = Math.Round(totalLohSize / 1024.0 / 1024.0, 2),
+                totalLohObjects = totalLohCount,
+                returnedCount = objects.Count,
+                objects
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "finalizer_queue")]
+    [Description("Show objects with finalizers - types that implement destructors/Dispose patterns")]
+    public static object FinalizerQueue(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Max objects to return (default 50)")] int limit = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            // Find objects whose types have finalizers
+            var objects = new List<object>();
+            var typeCounts = new Dictionary<string, (int count, long size)>();
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid || obj.Type == null) continue;
+
+                // Check if type has a finalizer
+                if (!obj.Type.IsFinalizable) continue;
+
+                var typeName = obj.Type.Name ?? "<unknown>";
+
+                if (!typeCounts.ContainsKey(typeName))
+                    typeCounts[typeName] = (0, 0);
+                var current = typeCounts[typeName];
+                typeCounts[typeName] = (current.count + 1, current.size + (long)obj.Size);
+
+                if (objects.Count < limit)
+                {
+                    objects.Add(new
+                    {
+                        address = $"0x{obj.Address:X}",
+                        type = typeName,
+                        size = obj.Size
+                    });
+                }
+            }
+
+            var typeStats = typeCounts
+                .OrderByDescending(kvp => kvp.Value.size)
+                .Take(20)
+                .Select(kvp => new { type = kvp.Key, count = kvp.Value.count, totalSize = kvp.Value.size })
+                .ToList();
+
+            return new
+            {
+                finalizableObjectCount = typeCounts.Values.Sum(v => v.count),
+                uniqueTypes = typeCounts.Count,
+                typeBreakdown = typeStats,
+                returnedCount = objects.Count,
+                objects,
+                note = "These are objects with finalizers. Large numbers may indicate missing Dispose() calls."
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "pinned_objects")]
+    [Description("Find pinned objects that prevent GC compaction")]
+    public static object PinnedObjects(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Max objects to return (default 50)")] int limit = 50)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            var pinnedRoots = heap.EnumerateRoots()
+                .Where(r => r.IsPinned)
+                .ToList();
+
+            var objects = new List<object>();
+            var typeCounts = new Dictionary<string, (int count, long size)>();
+            long totalPinnedSize = 0;
+
+            foreach (var root in pinnedRoots)
+            {
+                var obj = heap.GetObject(root.Object);
+                if (!obj.IsValid) continue;
+
+                var typeName = obj.Type?.Name ?? "<unknown>";
+                var size = (long)obj.Size;
+                totalPinnedSize += size;
+
+                if (!typeCounts.ContainsKey(typeName))
+                    typeCounts[typeName] = (0, 0);
+                var current = typeCounts[typeName];
+                typeCounts[typeName] = (current.count + 1, current.size + size);
+
+                if (objects.Count < limit)
+                {
+                    objects.Add(new
+                    {
+                        address = $"0x{obj.Address:X}",
+                        rootAddress = $"0x{root.Address:X}",
+                        rootKind = root.RootKind.ToString(),
+                        type = typeName,
+                        size = obj.Size
+                    });
+                }
+            }
+
+            var typeStats = typeCounts
+                .OrderByDescending(kvp => kvp.Value.size)
+                .Take(20)
+                .Select(kvp => new
+                {
+                    type = kvp.Key,
+                    count = kvp.Value.count,
+                    totalSizeBytes = kvp.Value.size
+                })
+                .ToList();
+
+            return new
+            {
+                totalPinnedObjects = pinnedRoots.Count,
+                totalPinnedSizeMB = Math.Round(totalPinnedSize / 1024.0 / 1024.0, 2),
+                uniqueTypes = typeCounts.Count,
+                typeBreakdown = typeStats,
+                returnedCount = objects.Count,
+                objects
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    [McpServerTool(Name = "duplicate_strings")]
+    [Description("Find duplicate string content - common source of memory waste")]
+    public static object DuplicateStrings(
+        [Description("Full path to the .dmp file")] string filePath,
+        [Description("Minimum string length to consider (default 20)")] int minLength = 20,
+        [Description("Minimum duplicate count to report (default 5)")] int minCount = 5,
+        [Description("Max results to return (default 30)")] int limit = 30)
+    {
+        if (!File.Exists(filePath))
+            return new { error = $"File not found: {filePath}" };
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return new { error = "No CLR found in dump - not a .NET process dump" };
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return new { error = "Heap is not in a walkable state" };
+
+            var stringCounts = new Dictionary<string, (int count, long totalSize)>();
+            long totalStrings = 0;
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid || obj.Type?.Name != "System.String") continue;
+
+                totalStrings++;
+                var str = obj.AsString();
+                if (str == null || str.Length < minLength) continue;
+
+                // Truncate very long strings for grouping
+                var key = str.Length > 500 ? str[..500] : str;
+
+                if (!stringCounts.ContainsKey(key))
+                    stringCounts[key] = (0, 0);
+
+                var current = stringCounts[key];
+                stringCounts[key] = (current.count + 1, current.totalSize + (long)obj.Size);
+            }
+
+            var duplicates = stringCounts
+                .Where(kvp => kvp.Value.count >= minCount)
+                .OrderByDescending(kvp => kvp.Value.totalSize)
+                .Take(limit)
+                .Select(kvp => new
+                {
+                    value = kvp.Key.Length > 100 ? kvp.Key[..100] + "..." : kvp.Key,
+                    fullLength = kvp.Key.Length,
+                    count = kvp.Value.count,
+                    wastedSizeBytes = kvp.Value.totalSize - (kvp.Value.totalSize / kvp.Value.count), // Size that could be saved
+                    wastedSizeKB = Math.Round((kvp.Value.totalSize - (kvp.Value.totalSize / kvp.Value.count)) / 1024.0, 1),
+                    totalSizeBytes = kvp.Value.totalSize
+                })
+                .ToList();
+
+            var totalWasted = duplicates.Sum(d => d.wastedSizeBytes);
+
+            return new
+            {
+                totalStringsAnalyzed = totalStrings,
+                duplicateGroupsFound = stringCounts.Count(kvp => kvp.Value.count >= minCount),
+                potentialSavingsMB = Math.Round(totalWasted / 1024.0 / 1024.0, 2),
+                returnedCount = duplicates.Count,
+                duplicates
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Analysis failed: {ex.Message}" };
+        }
+    }
+
+    private static (Dictionary<string, (long count, long size)> stats, string? error) GetHeapStats(string filePath)
+    {
+        var stats = new Dictionary<string, (long count, long size)>();
+
+        try
+        {
+            using var dataTarget = DataTarget.LoadDump(filePath);
+            var clrVersion = dataTarget.ClrVersions.FirstOrDefault();
+            if (clrVersion == null)
+                return (stats, "No CLR found in dump");
+
+            using var runtime = clrVersion.CreateRuntime();
+            var heap = runtime.Heap;
+
+            if (!heap.CanWalkHeap)
+                return (stats, "Heap is not walkable");
+
+            foreach (var obj in heap.EnumerateObjects())
+            {
+                if (!obj.IsValid) continue;
+
+                var typeName = obj.Type?.Name ?? "<unknown>";
+                var size = (long)obj.Size;
+
+                if (!stats.ContainsKey(typeName))
+                    stats[typeName] = (0, 0);
+
+                var current = stats[typeName];
+                stats[typeName] = (current.count + 1, current.size + size);
+            }
+
+            return (stats, null);
+        }
+        catch (Exception ex)
+        {
+            return (stats, ex.Message);
+        }
+    }
+}

--- a/src/Atlas.Server/Tools/ProcessTools.cs
+++ b/src/Atlas.Server/Tools/ProcessTools.cs
@@ -13,153 +13,177 @@ public static class ProcessTools
     [Description("List all running processes with basic information including parent PID and command line")]
     public static object ListProcesses(
         [Description("Optional: filter by process name (partial match)")] string? nameFilter = null,
-        [Description("Max results to return (default 50)")] int limit = 50)
+        [Description("Max results to return (default 50)")] int limit = 50,
+        [Description("Optional: remote machine name (e.g., 'SERVER01' or '192.168.1.100')")] string? hostname = null)
     {
-        var wmiProcesses = new Dictionary<int, (int parentPid, string commandLine)>();
-        
-        // Use WMI to get parent PID and command line (not available via System.Diagnostics)
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            try
-            {
-                using var searcher = new ManagementObjectSearcher("SELECT ProcessId, ParentProcessId, CommandLine FROM Win32_Process");
-                foreach (ManagementObject obj in searcher.Get())
-                {
-                    var pid = Convert.ToInt32(obj["ProcessId"]);
-                    var ppid = Convert.ToInt32(obj["ParentProcessId"] ?? 0);
-                    var cmdLine = obj["CommandLine"]?.ToString() ?? "";
-                    wmiProcesses[pid] = (ppid, cmdLine);
-                }
-            }
-            catch { /* WMI may fail for some processes */ }
+            return new { error = "This tool is only supported on Windows" };
         }
 
-        var processes = Process.GetProcesses()
-            .Where(p => string.IsNullOrEmpty(nameFilter) || 
-                        p.ProcessName.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
-            .Select(p =>
-            {
-                wmiProcesses.TryGetValue(p.Id, out var wmiInfo);
-                return new
-                {
-                    pid = p.Id,
-                    parentPid = wmiInfo.parentPid,
-                    name = p.ProcessName,
-                    commandLine = TruncateString(wmiInfo.commandLine, 200),
-                    memoryMB = p.WorkingSet64 / 1024 / 1024,
-                    threads = p.Threads.Count
-                };
-            })
-            .OrderByDescending(p => p.memoryMB)
-            .Take(limit)
-            .ToList();
+        try
+        {
+            var scope = GetManagementScope(hostname);
+            var processes = new List<object>();
 
-        return new { count = processes.Count, processes };
+            using var searcher = new ManagementObjectSearcher(scope,
+                new ObjectQuery("SELECT ProcessId, ParentProcessId, Name, CommandLine, WorkingSetSize, ThreadCount FROM Win32_Process"));
+
+            foreach (ManagementObject obj in searcher.Get())
+            {
+                var name = obj["Name"]?.ToString() ?? "";
+                if (!string.IsNullOrEmpty(nameFilter) &&
+                    !name.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                processes.Add(new
+                {
+                    pid = Convert.ToInt32(obj["ProcessId"]),
+                    parentPid = Convert.ToInt32(obj["ParentProcessId"] ?? 0),
+                    name,
+                    commandLine = TruncateString(obj["CommandLine"]?.ToString(), 200),
+                    memoryMB = Convert.ToInt64(obj["WorkingSetSize"] ?? 0) / 1024 / 1024,
+                    threads = Convert.ToInt32(obj["ThreadCount"] ?? 0)
+                });
+            }
+
+            var result = processes
+                .OrderByDescending(p => ((dynamic)p).memoryMB)
+                .Take(limit)
+                .ToList();
+
+            return new
+            {
+                count = result.Count,
+                hostname = hostname ?? Environment.MachineName,
+                isRemote = !string.IsNullOrEmpty(hostname),
+                processes = result
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = $"Failed to list processes: {ex.Message}", hostname };
+        }
     }
 
     [McpServerTool(Name = "get_process_details")]
     [Description("Get detailed information about a specific process including modules, threads, and environment")]
     public static object GetProcessDetails(
         [Description("Process ID to inspect")] int pid,
-        [Description("Include loaded modules list")] bool includeModules = false)
+        [Description("Include loaded modules list")] bool includeModules = false,
+        [Description("Optional: remote machine name (e.g., 'SERVER01' or '192.168.1.100')")] string? hostname = null)
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new { error = "This tool is only supported on Windows" };
+        }
+
         try
         {
-            var p = Process.GetProcessById(pid);
-            
-            // Get WMI info for command line and parent
-            int parentPid = 0;
-            string commandLine = "";
-            string executablePath = "";
-            
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            var scope = GetManagementScope(hostname);
+            var isRemote = !string.IsNullOrEmpty(hostname);
+
+            using var searcher = new ManagementObjectSearcher(scope,
+                new ObjectQuery($"SELECT * FROM Win32_Process WHERE ProcessId = {pid}"));
+
+            ManagementObject? processObj = null;
+            foreach (ManagementObject obj in searcher.Get())
+            {
+                processObj = obj;
+                break;
+            }
+
+            if (processObj == null)
+                return new { error = $"Process with PID {pid} not found", hostname };
+
+            var result = new Dictionary<string, object>
+            {
+                ["pid"] = pid,
+                ["parentPid"] = Convert.ToInt32(processObj["ParentProcessId"] ?? 0),
+                ["name"] = processObj["Name"]?.ToString() ?? "",
+                ["commandLine"] = processObj["CommandLine"]?.ToString() ?? "",
+                ["executablePath"] = processObj["ExecutablePath"]?.ToString() ?? "",
+                ["memoryMB"] = Convert.ToInt64(processObj["WorkingSetSize"] ?? 0) / 1024 / 1024,
+                ["virtualMemoryMB"] = Convert.ToInt64(processObj["VirtualSize"] ?? 0) / 1024 / 1024,
+                ["threads"] = Convert.ToInt32(processObj["ThreadCount"] ?? 0),
+                ["handleCount"] = Convert.ToInt32(processObj["HandleCount"] ?? 0),
+                ["priority"] = Convert.ToInt32(processObj["Priority"] ?? 0),
+                ["hostname"] = hostname ?? Environment.MachineName,
+                ["isRemote"] = isRemote
+            };
+
+            var creationDate = processObj["CreationDate"]?.ToString();
+            if (!string.IsNullOrEmpty(creationDate))
+            {
+                result["startTime"] = ManagementDateTimeConverter.ToDateTime(creationDate).ToString("o");
+            }
+
+            // For local processes, we can get additional info via System.Diagnostics
+            if (!isRemote)
             {
                 try
                 {
-                    using var searcher = new ManagementObjectSearcher(
-                        $"SELECT ParentProcessId, CommandLine, ExecutablePath FROM Win32_Process WHERE ProcessId = {pid}");
-                    foreach (ManagementObject obj in searcher.Get())
+                    var p = Process.GetProcessById(pid);
+                    result["mainWindowTitle"] = p.MainWindowTitle;
+                    try { result["cpuTimeSeconds"] = p.TotalProcessorTime.TotalSeconds; } catch { }
+
+                    if (includeModules)
                     {
-                        parentPid = Convert.ToInt32(obj["ParentProcessId"] ?? 0);
-                        commandLine = obj["CommandLine"]?.ToString() ?? "";
-                        executablePath = obj["ExecutablePath"]?.ToString() ?? "";
+                        try
+                        {
+                            var modules = p.Modules.Cast<ProcessModule>()
+                                .Select(m => new { name = m.ModuleName, path = m.FileName })
+                                .Take(50)
+                                .ToList();
+                            result["modules"] = modules;
+                            result["moduleCount"] = p.Modules.Count;
+                        }
+                        catch (Exception ex)
+                        {
+                            result["modulesError"] = ex.Message;
+                        }
                     }
                 }
                 catch { }
             }
 
-            var result = new Dictionary<string, object>
-            {
-                ["pid"] = p.Id,
-                ["parentPid"] = parentPid,
-                ["name"] = p.ProcessName,
-                ["commandLine"] = commandLine,
-                ["executablePath"] = executablePath,
-                ["memoryMB"] = p.WorkingSet64 / 1024 / 1024,
-                ["virtualMemoryMB"] = p.VirtualMemorySize64 / 1024 / 1024,
-                ["threads"] = p.Threads.Count,
-                ["handleCount"] = p.HandleCount,
-                ["priorityClass"] = p.PriorityClass.ToString(),
-                ["mainWindowTitle"] = p.MainWindowTitle
-            };
-
-            try { result["startTime"] = p.StartTime.ToString("o"); } catch { }
-            try { result["cpuTimeSeconds"] = p.TotalProcessorTime.TotalSeconds; } catch { }
-
-            if (includeModules)
-            {
-                try
-                {
-                    var modules = p.Modules.Cast<ProcessModule>()
-                        .Select(m => new { name = m.ModuleName, path = m.FileName })
-                        .Take(50)
-                        .ToList();
-                    result["modules"] = modules;
-                    result["moduleCount"] = p.Modules.Count;
-                }
-                catch (Exception ex)
-                {
-                    result["modulesError"] = ex.Message;
-                }
-            }
-
             return result;
-        }
-        catch (ArgumentException)
-        {
-            return new { error = $"Process with PID {pid} not found" };
         }
         catch (Exception ex)
         {
-            return new { error = ex.Message };
+            return new { error = $"Failed to get process details: {ex.Message}", hostname };
         }
     }
 
     [McpServerTool(Name = "get_process_tree")]
     [Description("Get process tree showing parent-child relationships")]
     public static object GetProcessTree(
-        [Description("Optional: root PID to start from (default: show all top-level)")] int? rootPid = null)
+        [Description("Optional: root PID to start from (default: show all top-level)")] int? rootPid = null,
+        [Description("Optional: remote machine name (e.g., 'SERVER01' or '192.168.1.100')")] string? hostname = null)
     {
-        var allProcesses = new Dictionary<int, (string name, int parentPid, long memoryMB)>();
-        var children = new Dictionary<int, List<int>>();
-
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return new { error = "Process tree is only supported on Windows" };
         }
 
+        var allProcesses = new Dictionary<int, (string name, int parentPid, long memoryMB)>();
+        var children = new Dictionary<int, List<int>>();
+
         try
         {
-            using var searcher = new ManagementObjectSearcher("SELECT ProcessId, ParentProcessId, Name, WorkingSetSize FROM Win32_Process");
+            var scope = GetManagementScope(hostname);
+            using var searcher = new ManagementObjectSearcher(scope,
+                new ObjectQuery("SELECT ProcessId, ParentProcessId, Name, WorkingSetSize FROM Win32_Process"));
+
             foreach (ManagementObject obj in searcher.Get())
             {
                 var pid = Convert.ToInt32(obj["ProcessId"]);
                 var ppid = Convert.ToInt32(obj["ParentProcessId"] ?? 0);
                 var name = obj["Name"]?.ToString() ?? "Unknown";
                 var memory = Convert.ToInt64(obj["WorkingSetSize"] ?? 0) / 1024 / 1024;
-                
+
                 allProcesses[pid] = (name, ppid, memory);
-                
+
                 if (!children.ContainsKey(ppid))
                     children[ppid] = new List<int>();
                 children[ppid].Add(pid);
@@ -167,7 +191,7 @@ public static class ProcessTools
         }
         catch (Exception ex)
         {
-            return new { error = $"Failed to enumerate processes: {ex.Message}" };
+            return new { error = $"Failed to enumerate processes: {ex.Message}", hostname };
         }
 
         object BuildTree(int pid, int depth = 0)
@@ -206,32 +230,35 @@ public static class ProcessTools
             .Select(kvp => BuildTree(kvp.Key))
             .ToList();
 
-        return new { count = topLevel.Count, trees = topLevel };
+        return new
+        {
+            count = topLevel.Count,
+            hostname = hostname ?? Environment.MachineName,
+            isRemote = !string.IsNullOrEmpty(hostname),
+            trees = topLevel
+        };
     }
 
     [McpServerTool(Name = "find_process")]
     [Description("Search for processes by name, command line, or PID")]
     public static object FindProcess(
-        [Description("Search query - matches name, command line, or PID")] string query)
+        [Description("Search query - matches name, command line, or PID")] string query,
+        [Description("Optional: remote machine name (e.g., 'SERVER01' or '192.168.1.100')")] string? hostname = null)
     {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new { error = "This tool is only supported on Windows" };
+        }
+
         var results = new List<object>();
         var isNumeric = int.TryParse(query, out var pidQuery);
 
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            // Fallback for non-Windows
-            var processes = Process.GetProcesses()
-                .Where(p => p.ProcessName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                           (isNumeric && p.Id == pidQuery))
-                .Take(20)
-                .Select(p => new { pid = p.Id, name = p.ProcessName, memoryMB = p.WorkingSet64 / 1024 / 1024 })
-                .ToList();
-            return new { count = processes.Count, matches = processes };
-        }
-
         try
         {
-            using var searcher = new ManagementObjectSearcher("SELECT ProcessId, Name, CommandLine, WorkingSetSize FROM Win32_Process");
+            var scope = GetManagementScope(hostname);
+            using var searcher = new ManagementObjectSearcher(scope,
+                new ObjectQuery("SELECT ProcessId, Name, CommandLine, WorkingSetSize FROM Win32_Process"));
+
             foreach (ManagementObject obj in searcher.Get())
             {
                 var pid = Convert.ToInt32(obj["ProcessId"]);
@@ -256,13 +283,32 @@ public static class ProcessTools
 
                 if (results.Count >= 20) break;
             }
+
+            return new
+            {
+                count = results.Count,
+                hostname = hostname ?? Environment.MachineName,
+                isRemote = !string.IsNullOrEmpty(hostname),
+                matches = results
+            };
         }
         catch (Exception ex)
         {
-            return new { error = $"Search failed: {ex.Message}" };
+            return new { error = $"Search failed: {ex.Message}", hostname };
+        }
+    }
+
+    private static ManagementScope GetManagementScope(string? hostname)
+    {
+        if (string.IsNullOrEmpty(hostname))
+        {
+            return new ManagementScope(@"\\.\root\cimv2");
         }
 
-        return new { count = results.Count, matches = results };
+        var path = $@"\\{hostname}\root\cimv2";
+        var scope = new ManagementScope(path);
+        scope.Connect();
+        return scope;
     }
 
     private static string TruncateString(string? value, int maxLength)


### PR DESCRIPTION
## Summary

This PR adds 15+ new diagnostic tools for analyzing .NET memory dumps and processes, addressing issues #9, #10, #13, and #14.

### Heap Analysis Tools (#9)
| Tool | Description |
|------|-------------|
| `dump_heap_stats` | Object count/size statistics by type (like `\!dumpheap -stat`) |
| `find_objects` | Find objects by type name (like `\!dumpheap -type`) |
| `dump_object` | Inspect object fields at address (like `\!do`) |
| `find_strings` | Find string objects with optional text filter |
| `gc_roots` | Find GC roots and referencing objects (like `\!gcroot`) |

### Memory Diagnostic Tools (#10)
| Tool | Description |
|------|-------------|
| `compare_heaps` | Diff two dumps to identify memory growth |
| `large_objects` | List objects on Large Object Heap (>85KB) |
| `finalizer_queue` | Show objects with finalizers |
| `pinned_objects` | Find pinned objects preventing GC compaction |
| `duplicate_strings` | Find duplicate string content (memory waste) |

### Crash/Hang Diagnosis Tools (#13)
| Tool | Description |
|------|-------------|
| `analyze_crash` | Auto-detect crash cause (like `\!analyze -v`) |
| `dump_exception` | Print exception with inner chain (like `\!pe`) |
| `dump_stack` | Detailed stack traces with signatures (like `\!clrstack`) |
| `detect_deadlocks` | Analyze thread lock wait patterns |
| `waiting_threads` | Show thread wait states |

### Remote Machine Support (#14)
- Added `hostname` parameter to process tools (`list_processes`, `get_process_details`, `get_process_tree`, `find_process`)
- Dumps can be loaded from UNC paths (`\server\share\dump.dmp`)

Fixes #9, #10, #13, #14

## Test plan
- [x] Build project successfully
- [x] Test heap analysis tools with a .NET dump
- [x] Test memory diagnostic tools
- [x] Test crash/hang diagnosis tools
- [x] Test process tools with hostname parameter
- [x] Verify network tools still include owningPid (bug #12 fix)
