### PR TITLE
chore: Add global.json to pin .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.416",
+    "rollForward": "latestPatch",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `global.json` to pin .NET SDK version to 8.0.416
- Uses `latestPatch` roll-forward policy (allows 8.0.416+ patches only)
- Ensures consistent builds across developer machines and CI

## Test plan
- [x] Verify `dotnet --version` respects the pinned version (returns 8.0.416)
- [x] Verify `dotnet build` succeeds