### PR TITLE
fix: Target net8.0-windows to resolve platform warnings

### DIFF
--- a/src/Atlas.Server/Atlas.Server.csproj
+++ b/src/Atlas.Server/Atlas.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Atlas.Server</RootNamespace>


### PR DESCRIPTION
## Summary
- Changes target framework from `net8.0` to `net8.0-windows`
- Eliminates CA1416 platform compatibility warnings
- Atlas is a Windows-only tool (uses WMI, P/Invoke to Windows APIs) so this is the correct target

## Before
```
3 Warning(s) - CA1416: ManagementScope is only supported on: 'windows'
```

## After
```
0 Warning(s)
```

## Test plan
- [x] `dotnet build` succeeds with 0 warnings