### PR TITLE
feat: Add build and prerequisites scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ Atlas is an MCP (Model Context Protocol) server that exposes Windows system diag
 
 ### Building from Source
 
-```bash
+```powershell
 git clone https://github.com/laveeshb/atlas.git
 cd atlas
-dotnet build src/Atlas.Server -c Release
+
+# Install prerequisites (checks for .NET 8 SDK)
+.\scripts\install-prereqs.ps1
+
+# Build
+.\scripts\build.ps1 -Release
 ```
 
-The built executable will be at `src/Atlas.Server/bin/Release/net8.0/Atlas.Server.exe`
+The built executable will be at `src/Atlas.Server/bin/Release/net8.0-windows/Atlas.Server.exe`
 
 ### MCP Configuration
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,149 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Builds the Atlas project.
+
+.DESCRIPTION
+    Cleans, restores, and builds the Atlas MCP server.
+
+.PARAMETER Configuration
+    Build configuration: Debug or Release. Default is Debug.
+
+.PARAMETER Clean
+    Clean build outputs before building.
+
+.PARAMETER Publish
+    Create a self-contained publish for distribution.
+
+.EXAMPLE
+    .\build.ps1
+
+.EXAMPLE
+    .\build.ps1 -Configuration Release
+
+.EXAMPLE
+    .\build.ps1 -Release -Publish
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Debug',
+
+    [Parameter()]
+    [switch]$Release,
+
+    [Parameter()]
+    [switch]$Clean,
+
+    [Parameter()]
+    [switch]$Publish
+)
+
+$ErrorActionPreference = 'Stop'
+
+# If -Release switch is used, override Configuration
+if ($Release) {
+    $Configuration = 'Release'
+}
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ProjectPath = Join-Path $RepoRoot "src\Atlas.Server\Atlas.Server.csproj"
+$OutputDir = Join-Path $RepoRoot "artifacts\$Configuration"
+
+function Write-Status($Message) {
+    Write-Host "[*] $Message" -ForegroundColor Cyan
+}
+
+function Write-Success($Message) {
+    Write-Host "[+] $Message" -ForegroundColor Green
+}
+
+function Write-Error($Message) {
+    Write-Host "[-] $Message" -ForegroundColor Red
+}
+
+# Main
+Write-Host ""
+Write-Host "Atlas Build Script" -ForegroundColor White
+Write-Host "==================" -ForegroundColor White
+Write-Host ""
+Write-Status "Configuration: $Configuration"
+Write-Host ""
+
+# Verify dotnet is available
+try {
+    $dotnetVersion = dotnet --version 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw ".NET SDK not found"
+    }
+    Write-Status "Using .NET SDK $dotnetVersion"
+}
+catch {
+    Write-Error ".NET SDK not found. Run .\scripts\install-prereqs.ps1 first."
+    exit 1
+}
+
+# Clean
+if ($Clean) {
+    Write-Status "Cleaning..."
+    dotnet clean $ProjectPath -c $Configuration --nologo -v q
+
+    if (Test-Path $OutputDir) {
+        Remove-Item $OutputDir -Recurse -Force
+    }
+}
+
+# Restore
+Write-Status "Restoring packages..."
+dotnet restore $ProjectPath --nologo -v q
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Restore failed"
+    exit 1
+}
+
+# Build
+Write-Status "Building..."
+dotnet build $ProjectPath -c $Configuration --no-restore --nologo
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Build failed"
+    exit 1
+}
+
+# Publish (optional)
+if ($Publish) {
+    Write-Status "Publishing self-contained executable..."
+
+    $PublishDir = Join-Path $OutputDir "publish"
+
+    dotnet publish $ProjectPath `
+        -c $Configuration `
+        -r win-x64 `
+        --self-contained true `
+        -p:PublishSingleFile=true `
+        -p:IncludeNativeLibrariesForSelfExtract=true `
+        -o $PublishDir `
+        --nologo
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Publish failed"
+        exit 1
+    }
+
+    Write-Success "Published to: $PublishDir"
+}
+
+Write-Host ""
+Write-Success "Build completed successfully!"
+Write-Host ""
+
+# Show output location
+$buildOutput = Join-Path $RepoRoot "src\Atlas.Server\bin\$Configuration\net8.0-windows"
+Write-Host "Output: $buildOutput" -ForegroundColor Gray
+
+if ($Publish) {
+    Write-Host "Publish: $PublishDir" -ForegroundColor Gray
+}
+
+Write-Host ""

--- a/scripts/install-prereqs.ps1
+++ b/scripts/install-prereqs.ps1
@@ -1,0 +1,131 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs prerequisites for building Atlas.
+
+.DESCRIPTION
+    Checks for required dependencies and installs them if missing.
+    Currently checks for .NET 8.0 SDK.
+
+.EXAMPLE
+    .\install-prereqs.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Status($Message) {
+    Write-Host "[*] $Message" -ForegroundColor Cyan
+}
+
+function Write-Success($Message) {
+    Write-Host "[+] $Message" -ForegroundColor Green
+}
+
+function Write-Warning($Message) {
+    Write-Host "[!] $Message" -ForegroundColor Yellow
+}
+
+function Write-Error($Message) {
+    Write-Host "[-] $Message" -ForegroundColor Red
+}
+
+function Test-DotNetSdk {
+    param([string]$RequiredVersion = "8.0")
+
+    try {
+        $sdks = dotnet --list-sdks 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            return $false
+        }
+
+        foreach ($sdk in $sdks) {
+            if ($sdk -match "^$RequiredVersion") {
+                return $true
+            }
+        }
+        return $false
+    }
+    catch {
+        return $false
+    }
+}
+
+function Install-DotNetSdk {
+    param([string]$Version = "8.0")
+
+    Write-Status "Downloading .NET $Version SDK installer..."
+
+    $installerUrl = "https://dot.net/v1/dotnet-install.ps1"
+    $installerPath = Join-Path $env:TEMP "dotnet-install.ps1"
+
+    try {
+        Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+
+        Write-Status "Installing .NET $Version SDK..."
+        & $installerPath -Channel $Version -InstallDir "$env:ProgramFiles\dotnet"
+
+        # Refresh PATH
+        $env:PATH = "$env:ProgramFiles\dotnet;$env:PATH"
+
+        Write-Success ".NET $Version SDK installed successfully"
+        Write-Warning "You may need to restart your terminal for PATH changes to take effect"
+    }
+    finally {
+        if (Test-Path $installerPath) {
+            Remove-Item $installerPath -Force
+        }
+    }
+}
+
+# Main
+Write-Host ""
+Write-Host "Atlas Prerequisites Installer" -ForegroundColor White
+Write-Host "==============================" -ForegroundColor White
+Write-Host ""
+
+# Check Windows version
+$os = [System.Environment]::OSVersion
+if ($os.Platform -ne 'Win32NT') {
+    Write-Error "Atlas requires Windows. Current platform: $($os.Platform)"
+    exit 1
+}
+
+$winVer = [System.Environment]::OSVersion.Version
+Write-Status "Windows version: $($winVer.Major).$($winVer.Minor).$($winVer.Build)"
+
+if ($winVer.Major -lt 10) {
+    Write-Warning "Atlas is designed for Windows 10/11 or Windows Server 2016+. Your version may not be fully supported."
+}
+
+# Check .NET SDK
+Write-Status "Checking for .NET 8.0 SDK..."
+
+if (Test-DotNetSdk -RequiredVersion "8.0") {
+    $currentSdk = (dotnet --version 2>$null)
+    Write-Success ".NET SDK $currentSdk is installed"
+}
+else {
+    Write-Warning ".NET 8.0 SDK not found"
+
+    $install = Read-Host "Would you like to install .NET 8.0 SDK? (y/n)"
+    if ($install -eq 'y' -or $install -eq 'Y') {
+        Install-DotNetSdk -Version "8.0"
+    }
+    else {
+        Write-Host ""
+        Write-Host "To install manually, download from:" -ForegroundColor White
+        Write-Host "https://dotnet.microsoft.com/download/dotnet/8.0" -ForegroundColor Cyan
+        exit 1
+    }
+}
+
+Write-Host ""
+Write-Success "All prerequisites satisfied!"
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor White
+Write-Host "  .\scripts\build.ps1          # Build the project" -ForegroundColor Gray
+Write-Host "  .\scripts\build.ps1 -Release # Build for release" -ForegroundColor Gray
+Write-Host ""


### PR DESCRIPTION
## Summary
- Adds `scripts/install-prereqs.ps1` - checks for .NET 8 SDK, offers to install if missing
- Adds `scripts/build.ps1` - builds the project with options

## Usage

```powershell
# Check/install prerequisites
.\scripts\install-prereqs.ps1

# Build (Debug)
.\scripts\build.ps1

# Build (Release)
.\scripts\build.ps1 -Release

# Build self-contained exe
.\scripts\build.ps1 -Release -Publish
```

## Test plan
- [x] `build.ps1` completes successfully
- [x] `install-prereqs.ps1` detects existing .NET SDK

Closes #24, Closes #25