### PR TITLE
test: Add integration tests for ProcessTools and NetworkTools

### DIFF
--- a/src/Atlas.Server.Tests/Atlas.Server.Tests.csproj
+++ b/src/Atlas.Server.Tests/Atlas.Server.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Atlas.Server\Atlas.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Atlas.Server.Tests/NetworkToolsTests.cs
+++ b/src/Atlas.Server.Tests/NetworkToolsTests.cs
@@ -1,0 +1,116 @@
+using Atlas.Server.Tools;
+using System.Text.Json;
+
+namespace Atlas.Server.Tests;
+
+public class NetworkToolsTests
+{
+    private static JsonElement ToJson(object result)
+    {
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    [Fact]
+    public void ListNetworkConnections_ReturnsConnectionList()
+    {
+        // Act
+        var result = NetworkTools.ListNetworkConnections();
+        var json = ToJson(result);
+
+        // Assert - should have count and connections fields
+        Assert.True(json.TryGetProperty("count", out _), "Should have count property");
+        Assert.True(json.TryGetProperty("connections", out _), "Should have connections property");
+    }
+
+    [Fact]
+    public void ListNetworkConnections_ConnectionsHaveExpectedFields()
+    {
+        // Act
+        var result = NetworkTools.ListNetworkConnections();
+        var json = ToJson(result);
+
+        // Assert
+        var connections = json.GetProperty("connections");
+
+        // Skip if no connections (valid on isolated systems)
+        if (connections.GetArrayLength() == 0)
+            return;
+
+        var first = connections[0];
+
+        // Verify expected fields exist
+        Assert.True(first.TryGetProperty("localAddress", out _), "Should have localAddress");
+        Assert.True(first.TryGetProperty("localPort", out _), "Should have localPort");
+        Assert.True(first.TryGetProperty("remoteAddress", out _), "Should have remoteAddress");
+        Assert.True(first.TryGetProperty("remotePort", out _), "Should have remotePort");
+        Assert.True(first.TryGetProperty("state", out _), "Should have state");
+        Assert.True(first.TryGetProperty("owningPid", out _), "Should have owningPid");
+    }
+
+    [Fact]
+    public void ListTcpListeners_ReturnsListenerList()
+    {
+        // Act
+        var result = NetworkTools.ListTcpListeners();
+        var json = ToJson(result);
+
+        // Assert - should have count and listeners fields
+        Assert.True(json.TryGetProperty("count", out _), "Should have count property");
+        Assert.True(json.TryGetProperty("listeners", out _), "Should have listeners property");
+    }
+
+    [Fact]
+    public void ListTcpListeners_ListenersHaveExpectedFields()
+    {
+        // Act
+        var result = NetworkTools.ListTcpListeners();
+        var json = ToJson(result);
+
+        // Assert
+        var listeners = json.GetProperty("listeners");
+
+        // Should have at least some listeners on a Windows system
+        Assert.True(listeners.GetArrayLength() > 0, "Should have at least one listener");
+
+        var first = listeners[0];
+
+        // Verify expected fields exist
+        Assert.True(first.TryGetProperty("address", out _), "Should have address");
+        Assert.True(first.TryGetProperty("port", out _), "Should have port");
+        Assert.True(first.TryGetProperty("owningPid", out _), "Should have owningPid");
+    }
+
+    [Fact]
+    public void ListTcpListeners_ContainsListeners()
+    {
+        // Act
+        var result = NetworkTools.ListTcpListeners();
+        var json = ToJson(result);
+
+        // Assert - Windows typically has some listeners
+        var listeners = json.GetProperty("listeners");
+        Assert.True(listeners.GetArrayLength() > 0, "Should have at least one listener");
+    }
+
+    [Fact]
+    public void ListTcpListeners_ResultsAreSortedByPort()
+    {
+        // Act
+        var result = NetworkTools.ListTcpListeners();
+        var json = ToJson(result);
+
+        // Assert
+        var listeners = json.GetProperty("listeners");
+        var ports = new List<int>();
+
+        foreach (var listener in listeners.EnumerateArray())
+        {
+            ports.Add(listener.GetProperty("port").GetInt32());
+        }
+
+        // Verify sorted
+        var sorted = ports.OrderBy(p => p).ToList();
+        Assert.Equal(sorted, ports);
+    }
+}

--- a/src/Atlas.Server.Tests/ProcessToolsTests.cs
+++ b/src/Atlas.Server.Tests/ProcessToolsTests.cs
@@ -1,0 +1,151 @@
+using Atlas.Server.Tools;
+using System.Text.Json;
+
+namespace Atlas.Server.Tests;
+
+public class ProcessToolsTests
+{
+    private static JsonElement ToJson(object result)
+    {
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    [Fact]
+    public void ListProcesses_ReturnsProcessList()
+    {
+        // Act
+        var result = ProcessTools.ListProcesses();
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("count", out var count), "Should have count property");
+        Assert.True(count.GetInt32() > 0, "Should return at least one process");
+
+        Assert.True(json.TryGetProperty("processes", out var processes), "Should have processes property");
+        Assert.True(processes.GetArrayLength() > 0, "Should have process items");
+    }
+
+    [Fact]
+    public void ListProcesses_WithNameFilter_FiltersResults()
+    {
+        // Act - filter for a process that should always exist
+        var result = ProcessTools.ListProcesses(nameFilter: "System");
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("processes", out var processes));
+
+        foreach (var proc in processes.EnumerateArray())
+        {
+            var name = proc.GetProperty("name").GetString();
+            Assert.Contains("System", name!, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void ListProcesses_WithLimit_RespectsLimit()
+    {
+        // Act
+        var result = ProcessTools.ListProcesses(limit: 5);
+        var json = ToJson(result);
+
+        // Assert
+        var count = json.GetProperty("count").GetInt32();
+        Assert.True(count <= 5, "Should respect limit parameter");
+    }
+
+    [Fact]
+    public void FindProcess_ByName_FindsExplorer()
+    {
+        // Act - explorer.exe should be running on any Windows desktop
+        var result = ProcessTools.FindProcess("explorer");
+        var json = ToJson(result);
+
+        // Assert - verify structure (may not find explorer on server/CI)
+        Assert.True(json.TryGetProperty("count", out _), "Should have count property");
+        Assert.True(json.TryGetProperty("matches", out _), "Should have matches property");
+    }
+
+    [Fact]
+    public void FindProcess_ByPid_FindsProcess()
+    {
+        // Arrange - use current process PID
+        var currentPid = Environment.ProcessId;
+
+        // Act
+        var result = ProcessTools.FindProcess(currentPid.ToString());
+        var json = ToJson(result);
+
+        // Assert
+        var count = json.GetProperty("count").GetInt32();
+        Assert.True(count >= 1, "Should find current process by PID");
+    }
+
+    [Fact]
+    public void GetProcessDetails_ForCurrentProcess_ReturnsDetails()
+    {
+        // Arrange
+        var currentPid = Environment.ProcessId;
+
+        // Act
+        var result = ProcessTools.GetProcessDetails(currentPid);
+        var json = ToJson(result);
+
+        // Assert - should not have error for own process
+        Assert.False(json.TryGetProperty("error", out _), "Should not error on own process");
+        Assert.Equal(currentPid, json.GetProperty("pid").GetInt32());
+        Assert.True(json.TryGetProperty("name", out _), "Should have name property");
+    }
+
+    [Fact]
+    public void GetProcessDetails_WithModules_IncludesModuleList()
+    {
+        // Arrange
+        var currentPid = Environment.ProcessId;
+
+        // Act
+        var result = ProcessTools.GetProcessDetails(currentPid, includeModules: true);
+        var json = ToJson(result);
+
+        // Assert - should have modules or modulesError (if access denied)
+        var hasModules = json.TryGetProperty("modules", out _);
+        var hasModulesError = json.TryGetProperty("modulesError", out _);
+        Assert.True(hasModules || hasModulesError, "Should have modules or modulesError");
+    }
+
+    [Fact]
+    public void GetProcessDetails_NonExistentPid_ReturnsError()
+    {
+        // Act - use an unlikely PID
+        var result = ProcessTools.GetProcessDetails(999999);
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("error", out _), "Should return error for non-existent PID");
+    }
+
+    [Fact]
+    public void GetProcessTree_ReturnsTreeStructure()
+    {
+        // Act
+        var result = ProcessTools.GetProcessTree();
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("count", out var count), "Should have count property");
+        Assert.True(count.GetInt32() > 0, "Should return process trees");
+        Assert.True(json.TryGetProperty("trees", out _), "Should have trees property");
+    }
+
+    [Fact]
+    public void GetProcessTree_ForSpecificPid_ReturnsTree()
+    {
+        // Arrange - use PID 4 (System) which always exists
+        var result = ProcessTools.GetProcessTree(rootPid: 4);
+        var json = ToJson(result);
+
+        // Assert
+        Assert.Equal(4, json.GetProperty("pid").GetInt32());
+    }
+}


### PR DESCRIPTION
## Summary

Adds integration test project with smoke tests for ProcessTools and NetworkTools.

### Test Coverage

**ProcessTools (10 tests)**
- `ListProcesses` - returns list, respects filter and limit
- `FindProcess` - finds by name and PID
- `GetProcessDetails` - returns details, handles modules, errors on invalid PID
- `GetProcessTree` - returns tree structure

**NetworkTools (6 tests)**
- `ListNetworkConnections` - returns connections with expected fields
- `ListTcpListeners` - returns listeners, sorted by port

### Approach
- Uses JSON serialization to verify response structure (avoids anonymous type issues)
- Tests run against live system state
- Gracefully handles edge cases (no connections, access denied)

## Test Results
```
Total tests: 16
     Passed: 16
```

Closes #18