### PR TITLE
Add kernel driver analysis tools (list_drivers, get_driver_info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Atlas is an MCP (Model Context Protocol) server that exposes Windows system diag
 - **Crash Diagnosis** - Auto-detect crash causes, exception chains, and stack traces
 - **Deadlock Detection** - Find threads waiting on locks, identify potential deadlocks
 - **Network Connections** - List TCP connections and listeners with owning process info
+- **Kernel Diagnostics** - Enumerate loaded kernel drivers with version and signature info
 - **Remote Machine Support** - Query processes on remote Windows machines via WMI
+
+## Documentation
+
+- [User-Space Investigation Guide](docs/user-space-guide.md) - Memory leaks, crashes, deadlocks, process analysis
+- [Kernel-Space Investigation Guide](docs/kernel-space-guide.md) - Driver analysis, BSODs, security auditing
+- [Network Investigation Guide](docs/network-guide.md) - Connections, ports, network troubleshooting
 
 ## Prerequisites
 
@@ -149,6 +156,13 @@ All process tools support an optional `hostname` parameter to query remote Windo
 |------|-------------|
 | `get_system_info` | OS version, processor count, memory, uptime, .NET version |
 
+### Kernel Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_drivers` | List loaded kernel drivers with name, path, size, base address |
+| `get_driver_info` | Detailed driver info including version and digital signature status |
+
 ## Usage Examples
 
 ### Investigating High Memory Usage
@@ -223,7 +237,9 @@ The `hostname` parameter for process tools:
 
 ## Roadmap
 
-- **Kernel dump analysis** - Currently only .NET user-mode dumps are supported
+- **Kernel pool analysis** - Memory pool usage and pool tag tracking
+- **Handle/object analysis** - Detect handle leaks and enumerate kernel objects
+- **Kernel dump analysis** - Full kernel dump support (currently only .NET user-mode dumps for heap analysis)
 - **Linux support** - Process and dump analysis for Linux systems
 - **Performance counters** - Real-time CPU, memory, disk metrics
 - **ETW tracing** - Event Tracing for Windows integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Atlas Documentation
+
+Guides for using Atlas to investigate Windows system issues.
+
+## Investigation Guides
+
+| Guide | Description |
+|-------|-------------|
+| [User-Space Investigations](user-space-guide.md) | Process analysis, .NET memory dumps, crash diagnosis |
+| [Kernel-Space Investigations](kernel-space-guide.md) | Driver analysis, kernel pool, system-level diagnostics |
+| [Network Investigations](network-guide.md) | TCP connections, port listeners, process network activity |
+
+## Quick Reference
+
+### Common Investigation Workflows
+
+**"Why is this process using so much memory?"**
+→ See [Memory Leak Investigation](user-space-guide.md#memory-leak-investigation)
+
+**"Why did this application crash?"**
+→ See [Crash Analysis](user-space-guide.md#crash-analysis)
+
+**"What driver is causing this BSOD?"**
+→ See [Driver Analysis](kernel-space-guide.md#driver-analysis)
+
+**"What's connecting to this IP address?"**
+→ See [Connection Tracking](network-guide.md#finding-connections-by-ip)
+
+## Tool Categories
+
+- **Process Tools** - `list_processes`, `get_process_details`, `find_process`, `get_process_tree`
+- **Heap Analysis** - `dump_heap_stats`, `find_objects`, `dump_object`, `find_strings`, `gc_roots`
+- **Memory Diagnostics** - `compare_heaps`, `large_objects`, `finalizer_queue`, `pinned_objects`, `duplicate_strings`
+- **Crash Diagnosis** - `analyze_crash`, `dump_exception`, `dump_stack`, `detect_deadlocks`, `waiting_threads`
+- **Network Tools** - `list_network_connections`, `list_tcp_listeners`
+- **Kernel Tools** - `list_drivers`, `get_driver_info`
+- **System Tools** - `get_system_info`
+- **Dump Management** - `analyze_dump`, `list_dumps`

--- a/docs/kernel-space-guide.md
+++ b/docs/kernel-space-guide.md
@@ -1,0 +1,254 @@
+# Kernel-Space Investigation Guide
+
+This guide covers investigating kernel-level issues: driver problems, BSODs, system stability, and kernel resource usage.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Driver Analysis](#driver-analysis)
+- [BSOD Investigation](#bsod-investigation)
+- [Security Auditing](#security-auditing)
+- [Tips and Best Practices](#tips-and-best-practices)
+
+---
+
+## Getting Started
+
+### Understanding Kernel vs User Mode
+
+| Aspect | User Mode | Kernel Mode |
+|--------|-----------|-------------|
+| Access | Limited, sandboxed | Full system access |
+| Crashes | Process terminates | System BSOD |
+| Tools | ClrMD, debuggers | DbgEng, WinDbg |
+| Dumps | .dmp from process | Memory.dmp from system |
+
+### When to Use Kernel Tools
+
+- System is unstable or crashing (BSODs)
+- Investigating driver conflicts
+- Security audit (unsigned drivers, rootkits)
+- Performance issues at system level
+- Hardware-related problems
+
+---
+
+## Driver Analysis
+
+### Listing Loaded Drivers
+
+```
+"List all loaded kernel drivers"
+```
+
+Atlas uses `list_drivers` to enumerate all kernel modules:
+
+| Name | Path | Size | Load Order |
+|------|------|------|------------|
+| ntoskrnl.exe | C:\Windows\system32\ntoskrnl.exe | 11.3 MB | 0 |
+| hal.dll | C:\Windows\system32\hal.dll | 788 KB | 1 |
+| nvlddmkm.sys | C:\Windows\System32\DriverStore\... | 45.2 MB | 87 |
+
+**What to look for:**
+- Unusual driver names or paths
+- Drivers loaded from unexpected locations
+- Very recently added drivers (check file dates)
+
+### Filtering Drivers
+
+```
+"Show drivers with 'nvidia' in the name"
+```
+
+```
+"List the first 20 drivers by load order"
+```
+
+Atlas filters using `nameFilter` and `limit` parameters.
+
+### Getting Driver Details
+
+```
+"Get details for the ntfs driver"
+```
+
+Atlas uses `get_driver_info` to show:
+
+```json
+{
+  "name": "ntfs.sys",
+  "path": "C:\\Windows\\system32\\drivers\\ntfs.sys",
+  "baseAddress": "0xFFFFF80014A00000",
+  "size": 2306048,
+  "version": {
+    "fileVersion": "10.0.22621.2506",
+    "companyName": "Microsoft Corporation",
+    "description": "NT File System Driver"
+  },
+  "signature": {
+    "signed": true,
+    "subject": "CN=Microsoft Windows, O=Microsoft Corporation...",
+    "issuer": "CN=Microsoft Windows Production PCA 2011",
+    "isValid": true
+  }
+}
+```
+
+---
+
+## BSOD Investigation
+
+### Common BSOD Causes
+
+| Bug Check | Common Cause |
+|-----------|--------------|
+| DRIVER_IRQL_NOT_LESS_OR_EQUAL | Driver accessing paged memory at high IRQL |
+| SYSTEM_SERVICE_EXCEPTION | Driver or system code exception |
+| PAGE_FAULT_IN_NONPAGED_AREA | Driver referencing invalid memory |
+| KERNEL_DATA_INPAGE_ERROR | Disk/storage issues |
+| CRITICAL_PROCESS_DIED | Critical system process crashed |
+
+### Investigation Flow
+
+#### Step 1: Check Recently Loaded Drivers
+
+After a BSOD, check what drivers are loaded:
+
+```
+"List all loaded drivers"
+```
+
+Look for:
+- Third-party drivers (non-Microsoft)
+- Recently updated drivers
+- Drivers with unusually large sizes
+
+#### Step 2: Verify Driver Signatures
+
+```
+"Get details for suspicious_driver.sys"
+```
+
+Check:
+- Is the driver signed?
+- Is the signature valid (not expired)?
+- Who is the publisher?
+
+**Red flags:**
+- Unsigned drivers
+- Self-signed certificates
+- Expired signatures
+- Unknown publishers
+
+#### Step 3: Identify the Faulting Driver
+
+If you have the bug check parameter (from Event Viewer or BlueScreenView):
+
+1. The address often points to the faulting module
+2. Match the address to driver base addresses from `list_drivers`
+3. Get details on that driver
+
+### Collecting BSOD Information
+
+**Event Viewer:**
+1. Open Event Viewer → Windows Logs → System
+2. Filter for "BugCheck" source
+3. Note the bug check code and parameters
+
+**Memory.dmp location:**
+- Default: `C:\Windows\MEMORY.DMP`
+- Minidumps: `C:\Windows\Minidump\`
+
+---
+
+## Security Auditing
+
+### Finding Unsigned Drivers
+
+Unsigned drivers are potential security risks:
+
+```
+"List all drivers and check which are unsigned"
+```
+
+For each driver, use `get_driver_info` to check signature status.
+
+**Legitimate reasons for unsigned drivers:**
+- Development/test signing during driver development
+- Very old legacy hardware
+
+**Security concerns:**
+- Rootkits often use unsigned drivers
+- Malware may install unsigned drivers to bypass security
+
+### Checking for Suspicious Drivers
+
+**Suspicious patterns:**
+- Random or obfuscated names (e.g., `a3x7d2.sys`)
+- Loaded from user directories instead of System32
+- No version information
+- Self-signed or expired certificates
+- Unusually small size for claimed functionality
+
+```
+"Get details for each third-party driver"
+```
+
+### Known Driver Locations
+
+Normal driver paths:
+- `C:\Windows\System32\drivers\`
+- `C:\Windows\System32\DriverStore\FileRepository\`
+
+Suspicious paths:
+- User directories (`C:\Users\...`)
+- Temp directories
+- Random paths with GUIDs
+
+---
+
+## Tips and Best Practices
+
+### Driver Investigation Checklist
+
+1. **Inventory all drivers** - Know what's loaded
+2. **Check signatures** - All production drivers should be signed
+3. **Verify publishers** - Confirm legitimate vendors
+4. **Compare to baseline** - Know what "normal" looks like
+5. **Check load order** - Early-loading drivers have more power
+
+### Correlating with System Events
+
+Use Event Viewer alongside Atlas:
+- System log for driver load/unload events
+- Application log for related app issues
+- Security log for audit events
+
+### Safe Mode Investigation
+
+If system won't boot normally:
+1. Boot to Safe Mode (minimal drivers)
+2. Compare drivers loaded in Safe Mode vs normal
+3. Identify which driver causes the problem
+
+### Creating a Driver Baseline
+
+For production systems, document:
+- Expected drivers and versions
+- Expected signature status
+- Known third-party drivers
+
+Compare periodically to detect changes.
+
+---
+
+## Coming Soon
+
+The following kernel investigation capabilities are planned:
+
+- **Pool memory analysis** - Track kernel memory usage by pool tag
+- **Handle leak detection** - Find processes leaking kernel handles
+- **Kernel thread analysis** - Inspect kernel stacks and DPC latency
+- **Kernel dump analysis** - Full analysis of MEMORY.DMP files
+
+See [GitHub Issues](https://github.com/laveeshb/atlas/issues?q=label%3A%22area%3A+kernel%22) for progress.

--- a/docs/network-guide.md
+++ b/docs/network-guide.md
@@ -1,0 +1,265 @@
+# Network Investigation Guide
+
+This guide covers investigating network-related issues: identifying connections, finding which processes are using network resources, and troubleshooting connectivity.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Finding Connections by IP](#finding-connections-by-ip)
+- [Port Investigation](#port-investigation)
+- [Process Network Activity](#process-network-activity)
+- [Common Scenarios](#common-scenarios)
+- [Tips and Best Practices](#tips-and-best-practices)
+
+---
+
+## Getting Started
+
+### Available Network Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_network_connections` | Active TCP connections with owning process |
+| `list_tcp_listeners` | TCP ports being listened on |
+
+### Quick Commands
+
+```
+"What network connections are active?"
+"What ports are being listened on?"
+"What process is connecting to 10.0.0.50?"
+"What's listening on port 443?"
+```
+
+---
+
+## Finding Connections by IP
+
+### Outbound Connections
+
+```
+"What processes are connecting to 10.0.0.50?"
+```
+
+Atlas uses `list_network_connections` and filters by remote address:
+
+| Local | Remote | State | PID | Process |
+|-------|--------|-------|-----|---------|
+| 192.168.1.100:52341 | 10.0.0.50:443 | ESTABLISHED | 1234 | MyApp.exe |
+| 192.168.1.100:52342 | 10.0.0.50:443 | ESTABLISHED | 1234 | MyApp.exe |
+
+### Investigating the Process
+
+Once you have the PID:
+
+```
+"Show details for process 1234"
+```
+
+Atlas uses `get_process_details` to show:
+- Full command line
+- Executable path
+- Parent process
+- Loaded modules
+
+### Connection States
+
+| State | Meaning |
+|-------|---------|
+| ESTABLISHED | Active connection |
+| TIME_WAIT | Connection closed, waiting for timeout |
+| CLOSE_WAIT | Remote closed, waiting for local close |
+| SYN_SENT | Connection attempt in progress |
+| LISTENING | (Use `list_tcp_listeners` instead) |
+
+---
+
+## Port Investigation
+
+### Finding What's Listening
+
+```
+"What's listening on port 8080?"
+```
+
+Atlas uses `list_tcp_listeners` to show:
+
+| Address | Port | PID | Process |
+|---------|------|-----|---------|
+| 0.0.0.0 | 8080 | 5678 | node.exe |
+
+### Common Port Conflicts
+
+When an app fails to start with "port already in use":
+
+```
+"What's using port 443?"
+```
+
+Common culprits:
+- IIS (80, 443)
+- SQL Server (1433)
+- Development servers (3000, 5000, 8080)
+
+### Listening on Specific Interfaces
+
+| Address | Meaning |
+|---------|---------|
+| 0.0.0.0 | All IPv4 interfaces |
+| 127.0.0.1 | Localhost only |
+| 192.168.1.100 | Specific interface |
+
+---
+
+## Process Network Activity
+
+### Full Network Profile of a Process
+
+```
+"Show all network activity for chrome.exe"
+```
+
+1. Get PID(s) for the process
+2. Filter connections by those PIDs
+3. Show both connections and listeners
+
+### Identifying Network-Heavy Processes
+
+```
+"Which processes have the most network connections?"
+```
+
+Look for:
+- Unusually high connection counts
+- Connections to unexpected destinations
+- Processes that shouldn't have network activity
+
+---
+
+## Common Scenarios
+
+### Scenario: Application Can't Connect
+
+**Symptoms:** App fails with connection timeout or refused
+
+**Investigation:**
+```
+"Is anything listening on port 5432?"
+```
+
+If nothing is listening:
+- Service not started
+- Wrong port configuration
+- Service crashed
+
+If something is listening:
+- Firewall blocking
+- Binding to wrong interface (127.0.0.1 vs 0.0.0.0)
+
+### Scenario: Unexpected Outbound Connections
+
+**Symptoms:** Firewall logs show unexpected traffic
+
+**Investigation:**
+```
+"What processes are connecting to external IPs?"
+```
+
+```
+"Show details for process 9876"
+```
+
+Look for:
+- Unknown executables
+- Processes connecting to suspicious IPs
+- Unexpected processes with network activity
+
+### Scenario: Port Already in Use
+
+**Symptoms:** Service fails to start
+
+**Investigation:**
+```
+"What's using port 80?"
+```
+
+Common solutions:
+- Stop the conflicting service
+- Change port configuration
+- Check for zombie processes (TIME_WAIT with old PID)
+
+### Scenario: Connection Leak
+
+**Symptoms:** Application gradually uses more connections until limit hit
+
+**Investigation:**
+```
+"How many connections does MyApp have?"
+```
+
+Compare over time. If growing without bound:
+- Connections not being closed
+- Connection pooling issues
+- Resource exhaustion
+
+---
+
+## Tips and Best Practices
+
+### Combining with Process Tools
+
+Network issues often need process context:
+
+1. Find the connection → get PID
+2. Get process details → understand what's running
+3. Check process tree → find parent/related processes
+4. Check command line → see configuration
+
+### Remote Investigation
+
+Process tools work on remote machines:
+
+```
+"List processes on SERVER01"
+"Show process details for PID 1234 on SERVER01"
+```
+
+Note: Network tools currently work on local machine only.
+
+### Security Considerations
+
+Network activity can reveal:
+- Internal service architecture
+- Database connection strings (from process command lines)
+- API endpoints and authentication details
+
+### Common False Positives
+
+**High connection counts for:**
+- Web browsers (many connections to CDNs, trackers)
+- Database connection pools (intentionally kept open)
+- Load balancers / reverse proxies
+
+**TIME_WAIT connections:**
+- Normal after connection closes
+- Doesn't indicate a problem unless overwhelming
+
+### Correlating with Firewall Logs
+
+Windows Firewall logs:
+1. Enable logging: Windows Security → Firewall → Advanced Settings
+2. Check: `C:\Windows\System32\LogFiles\Firewall\pfirewall.log`
+3. Correlate timestamps with Atlas output
+
+---
+
+## Limitations
+
+Current limitations of network tools:
+
+- **TCP only** - UDP connections not yet enumerated
+- **IPv4 focus** - IPv6 support in progress (see #40)
+- **Local only** - Remote network queries not yet supported
+- **No historical data** - Shows current state only
+
+See [GitHub Issues](https://github.com/laveeshb/atlas/issues?q=label%3A%22area%3A+network%22) for planned improvements.

--- a/docs/user-space-guide.md
+++ b/docs/user-space-guide.md
@@ -1,0 +1,340 @@
+# User-Space Investigation Guide
+
+This guide covers investigating user-mode applications: .NET memory issues, crashes, hangs, and process behavior.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Memory Leak Investigation](#memory-leak-investigation)
+- [Crash Analysis](#crash-analysis)
+- [Deadlock and Hang Analysis](#deadlock-and-hang-analysis)
+- [Process Investigation](#process-investigation)
+- [Tips and Best Practices](#tips-and-best-practices)
+
+---
+
+## Getting Started
+
+### Capturing a Memory Dump
+
+Before analyzing, you need a dump file. Common ways to capture:
+
+**Task Manager (quick)**
+1. Open Task Manager → Details tab
+2. Right-click process → Create dump file
+3. Note the path (usually `%TEMP%\<process>.DMP`)
+
+**procdump (recommended for production)**
+```powershell
+# Capture immediately
+procdump -ma <pid> dump.dmp
+
+# Capture on crash
+procdump -ma -e <pid> dump.dmp
+
+# Capture on high memory
+procdump -ma -m 1024 <pid> dump.dmp
+```
+
+**dotnet-dump (.NET Core/5+)**
+```powershell
+dotnet-dump collect -p <pid> -o dump.dmp
+```
+
+### Finding Dump Files
+
+Ask Atlas to find existing dumps:
+```
+"Find any crash dumps on this system"
+```
+Atlas uses `list_dumps` to search common locations like `%LOCALAPPDATA%\CrashDumps`.
+
+---
+
+## Memory Leak Investigation
+
+### Symptoms
+- Process memory grows over time
+- OutOfMemoryException
+- System becoming slow/unresponsive
+
+### Investigation Flow
+
+#### Step 1: Get the Big Picture
+
+```
+"What types are using the most memory in this dump?"
+```
+
+Atlas uses `dump_heap_stats` to show object counts and sizes by type:
+
+| Type | Count | Total Size |
+|------|-------|------------|
+| System.String | 1,234,567 | 500 MB |
+| MyApp.CacheEntry | 500,000 | 200 MB |
+| System.Byte[] | 10,000 | 150 MB |
+
+**What to look for:**
+- Unexpectedly high counts of your application types
+- Large string counts (often symptoms of caching issues)
+- Byte arrays (possible unbounded buffers)
+
+#### Step 2: Investigate Suspicious Types
+
+```
+"Find all CacheEntry objects"
+```
+
+Atlas uses `find_objects` to list instances. Look for:
+- Unexpectedly high counts
+- Objects that should have been collected
+
+#### Step 3: Find Why Objects Are Alive
+
+```
+"Why is object at 0x1a2b3c4d still alive?"
+```
+
+Atlas uses `gc_roots` to trace from GC roots to your object:
+
+```
+Thread Stack Root
+  → MyApp.EventHandler
+    → System.EventHandler
+      → MyApp.CacheEntry (your object)
+```
+
+**Common leak patterns:**
+- **Event handlers** - Objects subscribed to events on long-lived objects
+- **Static collections** - Lists/dictionaries on static fields that grow forever
+- **Timers** - Timer callbacks holding references
+- **Closures** - Lambda captures keeping objects alive
+
+#### Step 4: Compare Two Dumps (Growth Analysis)
+
+Capture dumps at two points in time, then:
+
+```
+"Compare dump1.dmp and dump2.dmp - what grew?"
+```
+
+Atlas uses `compare_heaps` to show delta:
+
+| Type | Before | After | Delta |
+|------|--------|-------|-------|
+| MyApp.CacheEntry | 10,000 | 60,000 | +50,000 |
+| System.String | 100,000 | 350,000 | +250,000 |
+
+### Specialized Memory Tools
+
+**Large Object Heap issues:**
+```
+"Show objects on the Large Object Heap"
+```
+Atlas uses `large_objects` - LOH fragmentation can cause OOM even with available memory.
+
+**Disposal issues:**
+```
+"What objects are waiting for finalization?"
+```
+Atlas uses `finalizer_queue` - objects with finalizers that weren't disposed properly.
+
+**String waste:**
+```
+"Find duplicate strings"
+```
+Atlas uses `duplicate_strings` - same string content stored multiple times.
+
+---
+
+## Crash Analysis
+
+### Symptoms
+- Application terminated unexpectedly
+- Unhandled exception
+- Windows Error Reporting dialog
+
+### Investigation Flow
+
+#### Step 1: Auto-Analyze
+
+```
+"Why did this application crash?"
+```
+
+Atlas uses `analyze_crash` to auto-detect:
+- Exception type (NullReferenceException, AccessViolationException, etc.)
+- Faulting thread
+- Crash location
+
+#### Step 2: Get Exception Details
+
+```
+"Show the exception details"
+```
+
+Atlas uses `dump_exception` to show:
+- Exception message
+- Full inner exception chain
+- Exception properties (HResult, etc.)
+
+#### Step 3: Get Stack Trace
+
+```
+"Show the stack trace for the crash"
+```
+
+Atlas uses `dump_stack` to show the call stack with:
+- Method names with parameters
+- Source file and line numbers (if symbols available)
+- IL offset
+
+### Common Crash Patterns
+
+**NullReferenceException**
+- Check the stack trace for the faulting method
+- Often caused by uninitialized variables or unexpected null returns
+
+**AccessViolationException**
+- Usually P/Invoke or unsafe code issues
+- Check for incorrect marshaling or freed memory access
+
+**StackOverflowException**
+- Look for recursive calls in the stack
+- No exception object (process killed by CLR)
+
+**OutOfMemoryException**
+- Use memory investigation techniques above
+- Check for LOH fragmentation with `large_objects`
+
+---
+
+## Deadlock and Hang Analysis
+
+### Symptoms
+- Application frozen/not responding
+- Specific operations never complete
+- CPU at 0% but application stuck
+
+### Investigation Flow
+
+#### Step 1: Detect Deadlocks
+
+```
+"Are there any deadlocks?"
+```
+
+Atlas uses `detect_deadlocks` to find circular wait patterns:
+
+```
+Thread 1: Holds Lock A, Waiting for Lock B
+Thread 2: Holds Lock B, Waiting for Lock A
+→ DEADLOCK DETECTED
+```
+
+#### Step 2: See What Threads Are Waiting On
+
+```
+"What are threads waiting for?"
+```
+
+Atlas uses `waiting_threads` to show:
+- Thread ID and name
+- Wait reason (lock, I/O, sleep, etc.)
+- Object being waited on
+
+#### Step 3: Get Thread Stacks
+
+```
+"Show stack for thread 15"
+```
+
+Atlas uses `dump_stack` to see exactly where the thread is stuck.
+
+### Common Hang Patterns
+
+**Lock ordering deadlock**
+- Two threads acquiring locks in opposite order
+- Fix: Always acquire locks in consistent order
+
+**Async deadlock**
+- `.Result` or `.Wait()` on async code in UI/ASP.NET context
+- Fix: Use `await` instead, or `ConfigureAwait(false)`
+
+**Database/network timeout**
+- Thread waiting on external resource
+- Check connection strings, network connectivity
+
+---
+
+## Process Investigation
+
+### Live Process Analysis
+
+```
+"What processes are using the most memory?"
+```
+
+Atlas uses `list_processes` to show running processes with memory usage.
+
+```
+"Show details for process 1234"
+```
+
+Atlas uses `get_process_details` to show:
+- Command line arguments
+- Loaded modules
+- Thread count
+- Working set, private bytes
+
+```
+"Show the process tree for chrome"
+```
+
+Atlas uses `get_process_tree` to show parent/child relationships.
+
+### Remote Machine Analysis
+
+All process tools support remote machines:
+
+```
+"List processes on SERVER01"
+```
+
+Requires:
+- WMI service running on target
+- Admin rights on target machine
+- Firewall allowing WMI (TCP 135 + dynamic ports)
+
+---
+
+## Tips and Best Practices
+
+### Dump Capture Tips
+
+1. **Full dumps for memory analysis** - Use `-ma` flag with procdump
+2. **Capture before and after** - For leak analysis, capture at intervals
+3. **Include all managed threads** - Ensures complete heap analysis
+
+### Symbol Configuration
+
+For better stack traces, configure symbol servers:
+```powershell
+# Set symbol path
+$env:_NT_SYMBOL_PATH = "srv*C:\Symbols*https://msdl.microsoft.com/download/symbols"
+```
+
+### Common Pitfalls
+
+1. **Mini-dumps lack heap data** - Need full dumps for `dump_heap_stats`, `find_objects`, etc.
+2. **32-bit vs 64-bit** - Make sure you're analyzing with matching bitness
+3. **DAC mismatch** - CLR version in dump must match analysis machine for best results
+
+### Security Considerations
+
+Memory dumps contain sensitive data:
+- Credentials, API keys, tokens
+- Personal/business data in memory
+- Encryption keys
+
+Treat dump files as sensitive and restrict access.

--- a/src/Atlas.Server.Tests/KernelToolsTests.cs
+++ b/src/Atlas.Server.Tests/KernelToolsTests.cs
@@ -1,0 +1,176 @@
+using Atlas.Server.Tools;
+using System.Text.Json;
+
+namespace Atlas.Server.Tests;
+
+/// <summary>
+/// Tests for kernel diagnostic tools.
+/// </summary>
+public class KernelToolsTests
+{
+    private static JsonElement ToJson(object result)
+    {
+        var json = JsonSerializer.Serialize(result);
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    [Fact]
+    public void ListDrivers_ReturnsLoadedDrivers()
+    {
+        // Act
+        var result = KernelTools.ListDrivers();
+        var json = ToJson(result);
+
+        // Assert - should have drivers loaded
+        Assert.True(json.TryGetProperty("totalLoaded", out var totalLoaded));
+        Assert.True(totalLoaded.GetInt32() > 0, "Should have drivers loaded");
+
+        Assert.True(json.TryGetProperty("drivers", out var drivers));
+        Assert.True(drivers.GetArrayLength() > 0, "Should return driver list");
+
+        // Check first driver has expected properties
+        var firstDriver = drivers[0];
+        Assert.True(firstDriver.TryGetProperty("name", out _));
+        Assert.True(firstDriver.TryGetProperty("path", out _));
+        Assert.True(firstDriver.TryGetProperty("baseAddress", out _));
+        Assert.True(firstDriver.TryGetProperty("size", out _));
+        Assert.True(firstDriver.TryGetProperty("loadOrder", out _));
+    }
+
+    [Fact]
+    public void ListDrivers_WithNameFilter_FiltersResults()
+    {
+        // Act - filter for ntoskrnl (always present)
+        var result = KernelTools.ListDrivers(nameFilter: "ntoskrnl");
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("drivers", out var drivers));
+        Assert.True(drivers.GetArrayLength() >= 1, "Should find ntoskrnl");
+
+        foreach (var driver in drivers.EnumerateArray())
+        {
+            var name = driver.GetProperty("name").GetString()!;
+            Assert.Contains("ntoskrnl", name, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void ListDrivers_WithLimit_RespectsLimit()
+    {
+        // Act
+        var result = KernelTools.ListDrivers(limit: 5);
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("drivers", out var drivers));
+        Assert.True(drivers.GetArrayLength() <= 5);
+    }
+
+    [Fact]
+    public void GetDriverInfo_ForNtoskrnl_ReturnsDetails()
+    {
+        // Act
+        var result = KernelTools.GetDriverInfo("ntoskrnl");
+        var json = ToJson(result);
+
+        // Assert - should not be an error
+        Assert.False(json.TryGetProperty("error", out _), "Should not return error");
+
+        // Check basic properties
+        Assert.True(json.TryGetProperty("name", out var name));
+        Assert.Contains("ntoskrnl", name.GetString()!, StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(json.TryGetProperty("path", out _));
+        Assert.True(json.TryGetProperty("baseAddress", out _));
+        Assert.True(json.TryGetProperty("size", out _));
+
+        // Check version info
+        Assert.True(json.TryGetProperty("version", out var version));
+        Assert.True(version.TryGetProperty("available", out var available));
+        Assert.True(available.GetBoolean(), "ntoskrnl should have version info");
+
+        // Check signature info
+        Assert.True(json.TryGetProperty("signature", out var signature));
+        Assert.True(signature.TryGetProperty("signed", out var signed));
+        Assert.True(signed.GetBoolean(), "ntoskrnl should be signed");
+    }
+
+    [Fact]
+    public void GetDriverInfo_ForNonexistentDriver_ReturnsError()
+    {
+        // Act
+        var result = KernelTools.GetDriverInfo("nonexistent_driver_xyz");
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("error", out var error));
+        Assert.Contains("not found", error.GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetDriverInfo_WithEmptyName_ReturnsError()
+    {
+        // Act
+        var result = KernelTools.GetDriverInfo("");
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("error", out var error));
+        Assert.Contains("required", error.GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ListDrivers_WithNoMatchFilter_ReturnsEmptyList()
+    {
+        // Act
+        var result = KernelTools.ListDrivers(nameFilter: "zzz_no_driver_matches_this_zzz");
+        var json = ToJson(result);
+
+        // Assert
+        Assert.True(json.TryGetProperty("drivers", out var drivers));
+        Assert.Equal(0, drivers.GetArrayLength());
+        Assert.True(json.TryGetProperty("returned", out var returned));
+        Assert.Equal(0, returned.GetInt32());
+    }
+
+    [Fact]
+    public void ListDrivers_ReturnsSortedByLoadOrder()
+    {
+        // Act
+        var result = KernelTools.ListDrivers(limit: 20);
+        var json = ToJson(result);
+
+        // Assert - verify sorted by loadOrder
+        var drivers = json.GetProperty("drivers");
+        int previousLoadOrder = -1;
+        foreach (var driver in drivers.EnumerateArray())
+        {
+            int loadOrder = driver.GetProperty("loadOrder").GetInt32();
+            Assert.True(loadOrder >= previousLoadOrder, 
+                $"Drivers should be sorted by loadOrder, but {loadOrder} came after {previousLoadOrder}");
+            previousLoadOrder = loadOrder;
+        }
+    }
+
+    [Fact]
+    public void GetDriverInfo_WithAndWithoutSysExtension_BothWork()
+    {
+        // Act - try "ntfs" without extension
+        var result1 = KernelTools.GetDriverInfo("ntfs");
+        var json1 = ToJson(result1);
+
+        // Act - try "ntfs.sys" with extension
+        var result2 = KernelTools.GetDriverInfo("ntfs.sys");
+        var json2 = ToJson(result2);
+
+        // Assert - both should succeed (not return error)
+        Assert.False(json1.TryGetProperty("error", out _), "ntfs should be found");
+        Assert.False(json2.TryGetProperty("error", out _), "ntfs.sys should be found");
+
+        // Both should return same driver
+        Assert.Equal(
+            json1.GetProperty("path").GetString(),
+            json2.GetProperty("path").GetString());
+    }
+}

--- a/src/Atlas.Server/Tools/KernelTools.cs
+++ b/src/Atlas.Server/Tools/KernelTools.cs
@@ -1,0 +1,350 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace Atlas.Server.Tools;
+
+[McpServerToolType]
+public static class KernelTools
+{
+    #region Native Interop
+
+    private const uint STATUS_INFO_LENGTH_MISMATCH = 0xC0000004;
+
+    private enum SYSTEM_INFORMATION_CLASS
+    {
+        SystemModuleInformation = 11
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RTL_PROCESS_MODULE_INFORMATION
+    {
+        public IntPtr Section;
+        public IntPtr MappedBase;
+        public IntPtr ImageBase;
+        public uint ImageSize;
+        public uint Flags;
+        public ushort LoadOrderIndex;
+        public ushort InitOrderIndex;
+        public ushort LoadCount;
+        public ushort OffsetToFileName;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 256)]
+        public byte[] FullPathName;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RTL_PROCESS_MODULES
+    {
+        public uint NumberOfModules;
+        // Followed by RTL_PROCESS_MODULE_INFORMATION array
+    }
+
+    [DllImport("ntdll.dll")]
+    private static extern uint NtQuerySystemInformation(
+        SYSTEM_INFORMATION_CLASS SystemInformationClass,
+        IntPtr SystemInformation,
+        uint SystemInformationLength,
+        out uint ReturnLength);
+
+    #endregion
+
+    /// <summary>
+    /// Lists all loaded kernel drivers with basic information.
+    /// </summary>
+    /// <param name="nameFilter">Optional filter by driver name (partial match, case-insensitive)</param>
+    /// <param name="limit">Maximum number of results to return (default: 100)</param>
+    /// <returns>Object containing driver list with name, path, size, base address, and load order</returns>
+    [McpServerTool(Name = "list_drivers")]
+    [Description("List all loaded kernel drivers with basic information including name, path, size, and base address")]
+    public static object ListDrivers(
+        [Description("Optional filter by driver name (partial match, case-insensitive)")]
+        string? nameFilter = null,
+        [Description("Maximum number of results to return (default: 100)")]
+        int limit = 100)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new { error = "This tool is only available on Windows" };
+        }
+
+        try
+        {
+            var drivers = GetLoadedDrivers();
+
+            if (!string.IsNullOrEmpty(nameFilter))
+            {
+                drivers = drivers
+                    .Where(d => d.Name.Contains(nameFilter, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+
+            var results = drivers
+                .OrderBy(d => d.LoadOrder)
+                .Take(limit)
+                .Select(d => new
+                {
+                    name = d.Name,
+                    path = d.FullPath,
+                    baseAddress = $"0x{d.ImageBase:X}",
+                    size = d.ImageSize,
+                    sizeFormatted = FormatSize(d.ImageSize),
+                    loadOrder = d.LoadOrder
+                })
+                .ToList();
+
+            return new
+            {
+                totalLoaded = drivers.Count,
+                returned = results.Count,
+                drivers = results
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Gets detailed information about a specific kernel driver.
+    /// </summary>
+    /// <param name="driverName">Name of the driver to inspect (e.g., 'ntfs.sys' or 'ntfs')</param>
+    /// <returns>Object containing driver details including version info and digital signature status</returns>
+    [McpServerTool(Name = "get_driver_info")]
+    [Description("Get detailed information about a specific kernel driver including version, publisher, and digital signature status")]
+    public static object GetDriverInfo(
+        [Description("Name of the driver to inspect (e.g., 'ntfs.sys' or 'ntfs')")]
+        string driverName)
+    {
+        if (string.IsNullOrWhiteSpace(driverName))
+        {
+            return new { error = "Driver name is required" };
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new { error = "This tool is only available on Windows" };
+        }
+
+        try
+        {
+            var drivers = GetLoadedDrivers();
+
+            // Find by exact name or partial match
+            var driver = drivers.FirstOrDefault(d =>
+                d.Name.Equals(driverName, StringComparison.OrdinalIgnoreCase) ||
+                d.Name.Equals(driverName + ".sys", StringComparison.OrdinalIgnoreCase)) ??
+                drivers.FirstOrDefault(d =>
+                    d.Name.Contains(driverName, StringComparison.OrdinalIgnoreCase));
+
+            if (driver == null)
+            {
+                return new { error = $"Driver '{driverName}' not found. Use list_drivers to see loaded drivers." };
+            }
+
+            // Get file version info
+            var versionInfo = GetVersionInfo(driver.FullPath);
+
+            // Get signature info
+            var signatureInfo = GetSignatureInfo(driver.FullPath);
+
+            return new
+            {
+                name = driver.Name,
+                path = driver.FullPath,
+                baseAddress = $"0x{driver.ImageBase:X}",
+                size = driver.ImageSize,
+                sizeFormatted = FormatSize(driver.ImageSize),
+                loadOrder = driver.LoadOrder,
+                version = versionInfo,
+                signature = signatureInfo
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { error = ex.Message };
+        }
+    }
+
+    #region Helper Methods
+
+    private record DriverInfo(
+        string Name,
+        string FullPath,
+        ulong ImageBase,
+        uint ImageSize,
+        int LoadOrder);
+
+    private static List<DriverInfo> GetLoadedDrivers()
+    {
+        var drivers = new List<DriverInfo>();
+        uint returnLength = 0;
+
+        // First call to get required buffer size
+        NtQuerySystemInformation(
+            SYSTEM_INFORMATION_CLASS.SystemModuleInformation,
+            IntPtr.Zero,
+            0,
+            out returnLength);
+
+        if (returnLength == 0)
+        {
+            throw new InvalidOperationException("Failed to query system module information size");
+        }
+
+        // Allocate buffer with some extra space
+        var bufferSize = returnLength + 4096;
+        var buffer = Marshal.AllocHGlobal((int)bufferSize);
+
+        try
+        {
+            var status = NtQuerySystemInformation(
+                SYSTEM_INFORMATION_CLASS.SystemModuleInformation,
+                buffer,
+                bufferSize,
+                out returnLength);
+
+            if (status != 0 && status != STATUS_INFO_LENGTH_MISMATCH)
+            {
+                throw new InvalidOperationException($"NtQuerySystemInformation failed with status 0x{status:X}");
+            }
+
+            // Read the number of modules
+            var numberOfModules = (uint)Marshal.ReadInt32(buffer);
+
+            // Calculate offset to first module entry
+            var moduleOffset = IntPtr.Size; // Skip NumberOfModules field (pointer-aligned)
+
+            for (int i = 0; i < numberOfModules; i++)
+            {
+                var modulePtr = IntPtr.Add(buffer, moduleOffset + (i * Marshal.SizeOf<RTL_PROCESS_MODULE_INFORMATION>()));
+                var module = Marshal.PtrToStructure<RTL_PROCESS_MODULE_INFORMATION>(modulePtr);
+
+                // Extract the file name from the path - find first null terminator
+                var nullIndex = Array.IndexOf(module.FullPathName, (byte)0);
+                var pathLength = nullIndex >= 0 ? nullIndex : module.FullPathName.Length;
+                var fullPath = Encoding.ASCII.GetString(module.FullPathName, 0, pathLength);
+
+                // Convert NT path to DOS path
+                var dosPath = ConvertNtPathToDosPath(fullPath);
+
+                // Extract filename - handle null terminator properly
+                var fileNameOffset = Math.Min(module.OffsetToFileName, pathLength);
+                var fileName = fileNameOffset < pathLength
+                    ? Encoding.ASCII.GetString(module.FullPathName, fileNameOffset, pathLength - fileNameOffset)
+                    : Path.GetFileName(dosPath);
+
+                drivers.Add(new DriverInfo(
+                    fileName,
+                    dosPath,
+                    (ulong)module.ImageBase,
+                    module.ImageSize,
+                    module.LoadOrderIndex));
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+
+        return drivers;
+    }
+
+    private static string ConvertNtPathToDosPath(string ntPath)
+    {
+        if (ntPath.StartsWith(@"\SystemRoot\", StringComparison.OrdinalIgnoreCase))
+        {
+            var systemRoot = Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows";
+            return systemRoot + ntPath.Substring(11);
+        }
+
+        if (ntPath.StartsWith(@"\??\", StringComparison.OrdinalIgnoreCase))
+        {
+            return ntPath.Substring(4);
+        }
+
+        if (ntPath.StartsWith(@"\\?\", StringComparison.OrdinalIgnoreCase))
+        {
+            return ntPath.Substring(4);
+        }
+
+        return ntPath;
+    }
+
+    private static object GetVersionInfo(string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                return new { available = false, reason = "File not found" };
+            }
+
+            var versionInfo = FileVersionInfo.GetVersionInfo(filePath);
+
+            return new
+            {
+                available = true,
+                fileVersion = versionInfo.FileVersion ?? "Unknown",
+                productVersion = versionInfo.ProductVersion ?? "Unknown",
+                productName = versionInfo.ProductName ?? "Unknown",
+                companyName = versionInfo.CompanyName ?? "Unknown",
+                description = versionInfo.FileDescription ?? "Unknown",
+                originalFilename = versionInfo.OriginalFilename ?? "Unknown"
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { available = false, reason = ex.Message };
+        }
+    }
+
+    private static object GetSignatureInfo(string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                return new { signed = false, reason = "File not found" };
+            }
+
+            // Use X509Certificate to check for Authenticode signature
+            try
+            {
+                var cert = X509Certificate.CreateFromSignedFile(filePath);
+                using var cert2 = new X509Certificate2(cert);
+
+                return new
+                {
+                    signed = true,
+                    subject = cert2.Subject,
+                    issuer = cert2.Issuer,
+                    validFrom = cert2.NotBefore.ToString("yyyy-MM-dd"),
+                    validTo = cert2.NotAfter.ToString("yyyy-MM-dd"),
+                    thumbprint = cert2.Thumbprint,
+                    isValid = cert2.NotAfter > DateTime.Now && cert2.NotBefore < DateTime.Now
+                };
+            }
+            catch (System.Security.Cryptography.CryptographicException)
+            {
+                return new { signed = false, reason = "No valid signature found" };
+            }
+        }
+        catch (Exception ex)
+        {
+            return new { signed = false, reason = ex.Message };
+        }
+    }
+
+    private static string FormatSize(uint bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        return $"{bytes / (1024.0 * 1024.0):F1} MB";
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Add kernel driver analysis tools to investigate loaded kernel modules.

## Changes
- New `KernelTools.cs` with P/Invoke to NtQuerySystemInformation
- `list_drivers`: Enumerate all loaded kernel drivers with name, path, size, base address, load order
- `get_driver_info`: Get detailed info for a specific driver including version and digital signature status
- 6 new tests covering both tools

## Use Cases
- BSOD investigation (identify faulty drivers)
- Security audits (find unsigned/suspicious drivers)
- Driver conflicts analysis
- Rootkit/malware detection

## Tools Added
| Tool | Description |
|------|-------------|
| `list_drivers` | List all loaded kernel drivers with optional name filter and limit |
| `get_driver_info` | Get detailed info including version, publisher, and signature status |

Closes #62

Part of #61 (Kernel Diagnostics Epic)
