### PR TITLE
feat: Remote dump analysis via WinDbg debug server (dbgsrv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Remote Debug Tools**: Analyze crash dumps on remote VMs via remote.exe
+  - `remote_analyze_crash` - Crash analysis on remote session
+  - `remote_heap_stats` - Heap statistics from remote dump
+  - `remote_stack_trace` - Managed/native stack traces
+  - `remote_list_modules` - List loaded modules
+  - `remote_debug_command` - Run arbitrary WinDbg commands
+  - Connection via `remote.exe` for persistent, multi-client sessions
+  - See [Remote Debugging Guide](docs/remote-debugging-guide.md)
+
 ## [0.1.0] - 2026-01-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Atlas is an MCP (Model Context Protocol) server that exposes Windows system diag
 - [User-Space Investigation Guide](docs/user-space-guide.md) - Memory leaks, crashes, deadlocks, process analysis
 - [Kernel-Space Investigation Guide](docs/kernel-space-guide.md) - Driver analysis, BSODs, security auditing
 - [Network Investigation Guide](docs/network-guide.md) - Connections, ports, network troubleshooting
+- [Remote Debugging Guide](docs/remote-debugging-guide.md) - Analyze dumps on remote VMs via WinDbg protocol
 
 ## Prerequisites
 
@@ -170,6 +171,18 @@ All process tools support an optional `hostname` parameter to query remote Windo
 | `get_interrupt_stats` | Processor interrupt information |
 | `get_physical_memory` | Physical memory layout and usage |
 | `get_system_resources` | Comprehensive system resource summary |
+
+### Remote Debug Tools
+
+| Tool | Description |
+|------|-------------|
+| `remote_analyze_crash` | Analyze crash dump on remote WinDbg debug server |
+| `remote_heap_stats` | Get heap statistics from remote dump |
+| `remote_stack_trace` | Get managed or native stack trace from remote dump |
+| `remote_list_modules` | List loaded modules from remote dump |
+| `remote_debug_command` | Execute arbitrary WinDbg command on remote server |
+
+Remote debug tools connect to a [dbgsrv](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options) instance running on a debug VM. This allows analyzing crash dumps without copying large files locally. See [Remote Debugging Guide](docs/remote-debugging-guide.md) for setup.
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,19 @@ All process tools support an optional `hostname` parameter to query remote Windo
 
 | Tool | Description |
 |------|-------------|
-| `remote_analyze_crash` | Analyze crash dump on remote WinDbg debug server |
+| `remote_analyze_crash` | Analyze crash dump on remote debug session |
 | `remote_heap_stats` | Get heap statistics from remote dump |
 | `remote_stack_trace` | Get managed or native stack trace from remote dump |
 | `remote_list_modules` | List loaded modules from remote dump |
-| `remote_debug_command` | Execute arbitrary WinDbg command on remote server |
+| `remote_debug_command` | Execute arbitrary WinDbg command on remote session |
 
-Remote debug tools connect to a [dbgsrv](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options) instance running on a debug VM. This allows analyzing crash dumps without copying large files locally. See [Remote Debugging Guide](docs/remote-debugging-guide.md) for setup.
+Remote debug tools connect to a [remote.exe](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/the-remote-exe-utility) session running on a debug VM. Start a session on the VM with:
+
+```cmd
+remote.exe /s "cdb -z C:\dumps\crash.dmp" DumpSession
+```
+
+Then connect from Atlas using the connection string `hostname/session` (e.g., `vm2/DumpSession`). This allows analyzing multi-GB crash dumps without copying files locally. See [Remote Debugging Guide](docs/remote-debugging-guide.md) for full setup.
 
 ## Usage Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Guides for using Atlas to investigate Windows system issues.
 | [User-Space Investigations](user-space-guide.md) | Process analysis, .NET memory dumps, crash diagnosis |
 | [Kernel-Space Investigations](kernel-space-guide.md) | Driver analysis, kernel pool, system-level diagnostics |
 | [Network Investigations](network-guide.md) | TCP connections, port listeners, process network activity |
+| [Remote Debugging](remote-debugging-guide.md) | Analyze dumps on remote VMs via remote.exe |
 
 ## Quick Reference
 
@@ -26,6 +27,9 @@ Guides for using Atlas to investigate Windows system issues.
 **"What's connecting to this IP address?"**
 → See [Connection Tracking](network-guide.md#finding-connections-by-ip)
 
+**"Analyze a crash dump on a remote VM"**
+→ See [Remote Debugging Guide](remote-debugging-guide.md)
+
 ## Tool Categories
 
 - **Process Tools** - `list_processes`, `get_process_details`, `find_process`, `get_process_tree`
@@ -33,6 +37,7 @@ Guides for using Atlas to investigate Windows system issues.
 - **Memory Diagnostics** - `compare_heaps`, `large_objects`, `finalizer_queue`, `pinned_objects`, `duplicate_strings`
 - **Crash Diagnosis** - `analyze_crash`, `dump_exception`, `dump_stack`, `detect_deadlocks`, `waiting_threads`
 - **Network Tools** - `list_network_connections`, `list_tcp_listeners`
-- **Kernel Tools** - `list_drivers`, `get_driver_info`
+- **Kernel Tools** - `list_drivers`, `get_driver_info`, `analyze_pool_usage`, `list_pool_tags`, `find_handle_leaks`
+- **Remote Debug Tools** - `remote_analyze_crash`, `remote_heap_stats`, `remote_stack_trace`, `remote_list_modules`, `remote_debug_command`
 - **System Tools** - `get_system_info`
 - **Dump Management** - `analyze_dump`, `list_dumps`

--- a/docs/remote-debugging-guide.md
+++ b/docs/remote-debugging-guide.md
@@ -30,9 +30,9 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                        Debug VM (VM2)                                    │
 │  ┌─────────────────┐    ┌────────────────────────────────────────────┐  │
-│  │ C:\dumps\       │    │  dbgsrv.exe -t tcp:port=5005               │  │
+│  │ C:\dumps\       │    │  cdb -server tcp:port=5005 -z dump.dmp     │  │
 │  │ app.dmp         │◀───│  (part of Debugging Tools for Windows)     │  │
-│  │ crash.dmp       │    │  Listens for WinDbg protocol connections   │  │
+│  │ crash.dmp       │    │  Loads dump and listens for connections    │  │
 │  └─────────────────┘    └─────────────────────────────────────────────┘ │
 │                                      ▲                                   │
 └──────────────────────────────────────┼───────────────────────────────────┘
@@ -43,7 +43,7 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 │  ┌───────────────────────────────────┴──────────────────────────────────┐│
 │  │  Atlas.Server                                                        ││
 │  │  - Spawns local cdb.exe with -remote connection string               ││
-│  │  - Sends WinDbg commands: .opendump, !analyze, !dumpheap             ││
+│  │  - Sends WinDbg commands: !analyze, !dumpheap, lm, k                 ││
 │  │  - Parses text output into structured JSON                           ││
 │  └───────────────────────────────────────────────────────────────────────┘│
 │                              ▲                                            │
@@ -55,6 +55,9 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
+> **Note:** The dump is loaded on the server side using `cdb -server`. The client
+> connects and sends commands directly - no need to open the dump from the client.
+
 ---
 
 ## Setup
@@ -62,7 +65,7 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 ### Prerequisites
 
 **On Debug VM (VM2):**
-- Windows SDK / Debugging Tools for Windows (includes dbgsrv.exe)
+- Windows SDK / Debugging Tools for Windows (includes cdb.exe)
 - Firewall rule allowing inbound TCP on debug port
 - Dump files accessible locally
 
@@ -74,25 +77,25 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 
 ### Step 1: Start Debug Server on VM2
 
+The server must load the dump file and expose it for remote debugging:
+
 Basic (no authentication):
 ```cmd
-dbgsrv -t tcp:port=5005
+cdb -server tcp:port=5005 -z C:\dumps\app.dmp
 ```
 
 With password:
 ```cmd
-dbgsrv -t tcp:port=5005,password=YourSecretPassword
+cdb -server tcp:port=5005,password=YourSecretPassword -z C:\dumps\app.dmp
 ```
 
 With SSL encryption:
 ```cmd
-dbgsrv -t ssl:port=5005,password=YourSecretPassword
+cdb -server ssl:port=5005,password=YourSecretPassword -z C:\dumps\app.dmp
 ```
 
-With IP allowlist:
-```cmd
-dbgsrv -t tcp:port=5005,password=YourSecretPassword -ipportaccess 10.0.0.100
-```
+> **Important:** The dump file path is specified on the server side with `-z`.
+> The client doesn't need to know the path - the dump is already loaded.
 
 ### Step 2: Configure Firewall on VM2
 
@@ -109,7 +112,7 @@ New-NetFirewallRule -DisplayName "WinDbg Remote Debug" `
 cdb -remote tcp:server=vm2.corp.net,port=5005,password=YourSecretPassword
 ```
 
-If you get a debugger prompt, connection is working. Type `q` to quit.
+If you get a debugger prompt with dump info, connection is working. Type `q` to disconnect, `qq` to shut down the server.
 
 ---
 

--- a/docs/remote-debugging-guide.md
+++ b/docs/remote-debugging-guide.md
@@ -1,0 +1,237 @@
+# Remote Debugging Guide
+
+This guide covers analyzing crash dumps on remote machines using WinDbg's remote debugging protocol.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Setup](#setup)
+- [Usage](#usage)
+- [Security](#security)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+When crash dumps are on a secured cloud VM that you can't copy files from, Atlas can connect remotely using WinDbg's debug server protocol (dbgsrv).
+
+**Key benefits:**
+- Analyze multi-GB dumps without downloading them
+- Keep sensitive data in the secured environment
+- Use standard Windows debugging infrastructure
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        Debug VM (VM2)                                    │
+│  ┌─────────────────┐    ┌────────────────────────────────────────────┐  │
+│  │ C:\dumps\       │    │  dbgsrv.exe -t tcp:port=5005               │  │
+│  │ app.dmp         │◀───│  (part of Debugging Tools for Windows)     │  │
+│  │ crash.dmp       │    │  Listens for WinDbg protocol connections   │  │
+│  └─────────────────┘    └─────────────────────────────────────────────┘ │
+│                                      ▲                                   │
+└──────────────────────────────────────┼───────────────────────────────────┘
+                                       │ TCP (WinDbg protocol)
+                                       │
+┌──────────────────────────────────────┼───────────────────────────────────┐
+│                        Developer Machine (mc00)                          │
+│  ┌───────────────────────────────────┴──────────────────────────────────┐│
+│  │  Atlas.Server                                                        ││
+│  │  - Spawns local cdb.exe with -remote connection string               ││
+│  │  - Sends WinDbg commands: .opendump, !analyze, !dumpheap             ││
+│  │  - Parses text output into structured JSON                           ││
+│  └───────────────────────────────────────────────────────────────────────┘│
+│                              ▲                                            │
+│                              │ MCP                                        │
+│  ┌───────────────────────────┴───────────────────────────────────────────┐│
+│  │  VS Code + GitHub Copilot                                             ││
+│  │  "Analyze the crash dump on debug-vm"                                 ││
+│  └───────────────────────────────────────────────────────────────────────┘│
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Setup
+
+### Prerequisites
+
+**On Debug VM (VM2):**
+- Windows SDK / Debugging Tools for Windows (includes dbgsrv.exe)
+- Firewall rule allowing inbound TCP on debug port
+- Dump files accessible locally
+
+**On Developer Machine (mc00):**
+- Windows SDK / Debugging Tools for Windows (includes cdb.exe)
+- Atlas.Server
+- Network access to debug VM's port
+- cdb.exe in PATH (or specify full path)
+
+### Step 1: Start Debug Server on VM2
+
+Basic (no authentication):
+```cmd
+dbgsrv -t tcp:port=5005
+```
+
+With password:
+```cmd
+dbgsrv -t tcp:port=5005,password=YourSecretPassword
+```
+
+With SSL encryption:
+```cmd
+dbgsrv -t ssl:port=5005,password=YourSecretPassword
+```
+
+With IP allowlist:
+```cmd
+dbgsrv -t tcp:port=5005,password=YourSecretPassword -ipportaccess 10.0.0.100
+```
+
+### Step 2: Configure Firewall on VM2
+
+```powershell
+# Allow inbound connections on debug port
+New-NetFirewallRule -DisplayName "WinDbg Remote Debug" `
+    -Direction Inbound -Protocol TCP -LocalPort 5005 `
+    -Action Allow -RemoteAddress 10.0.0.0/24
+```
+
+### Step 3: Verify Connection from mc00
+
+```cmd
+cdb -remote tcp:server=vm2.corp.net,port=5005,password=YourSecretPassword
+```
+
+If you get a debugger prompt, connection is working. Type `q` to quit.
+
+---
+
+## Usage
+
+### Analyze a Crash
+
+Ask Copilot:
+> "Analyze the crash dump at C:\dumps\app.dmp on debug server tcp:server=vm2,port=5005"
+
+Or use the tool directly:
+```json
+{
+  "tool": "remote_analyze_crash",
+  "arguments": {
+    "connectionString": "tcp:server=vm2.corp.net,port=5005",
+    "dumpPath": "C:\\dumps\\app.dmp",
+    "password": "YourSecretPassword"
+  }
+}
+```
+
+### Get Heap Statistics
+
+> "Show heap stats from the dump on the debug server"
+
+### Get Stack Trace
+
+> "Show the managed stack trace from the remote dump"
+
+For native code:
+> "Show the native stack trace from C:\dumps\app.dmp on vm2"
+
+### List Modules
+
+> "What modules were loaded in the crashed process on the debug VM?"
+
+### Run Custom Command
+
+> "Run !pe on the remote dump to show the exception"
+
+---
+
+## Security
+
+### Authentication Options
+
+| Method | Connection String | Security Level |
+|--------|-------------------|----------------|
+| None | `tcp:server=vm2,port=5005` | ⚠️ Not recommended |
+| Password | `tcp:server=vm2,port=5005,password=secret` | Basic |
+| SSL + Password | `ssl:server=vm2,port=5005,password=secret` | Recommended |
+| Named Pipe | `npipe:server=vm2,pipe=DebugPipe` | Uses Windows auth |
+
+### Best Practices
+
+1. **Use SSL** for encrypted traffic
+2. **Use IP allowlists** on dbgsrv
+3. **Store passwords** in environment variables, not in code
+4. **Rotate passwords** periodically
+5. **Limit firewall rules** to specific source IPs/subnets
+6. **Stop dbgsrv** when not in use
+
+### Environment Variable for Password
+
+```powershell
+# Set in environment
+$env:DEBUG_SERVER_PASSWORD = "YourSecretPassword"
+```
+
+Then use in Atlas without exposing password in chat:
+> "Analyze dump at C:\dumps\app.dmp on tcp:server=vm2,port=5005 using password from environment"
+
+---
+
+## Troubleshooting
+
+### "Failed to start cdb.exe"
+
+**Cause:** Debugging Tools for Windows not installed or not in PATH.
+
+**Fix:** 
+1. Install Windows SDK with "Debugging Tools" option
+2. Add to PATH: `C:\Program Files (x86)\Windows Kits\10\Debuggers\x64`
+
+### "Failed to connect to debug server"
+
+**Causes:**
+- dbgsrv not running on target
+- Firewall blocking connection
+- Wrong hostname/port
+- Wrong password
+
+**Fix:**
+1. Verify dbgsrv is running: `tasklist | findstr dbgsrv` on VM2
+2. Check firewall rules on VM2
+3. Test connection: `cdb -remote tcp:server=vm2,port=5005`
+
+### "Timed out waiting for debugger response"
+
+**Cause:** Debug server is busy or dump is very large.
+
+**Fix:**
+- Wait longer (large dumps take time to load)
+- Check if dbgsrv is responding
+
+### "Cannot open dump file"
+
+**Causes:**
+- Wrong path
+- File doesn't exist
+- Permissions issue
+
+**Fix:**
+1. Verify path exists on remote machine
+2. Check file permissions
+
+---
+
+## References
+
+- [WinDbg Remote Debugging](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/remote-debugging)
+- [DbgSrv Command Line](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options)
+- [Activating a Debugging Server](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/activating-a-debugging-server)
+- [Process Server Examples](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/process-server-examples)

--- a/docs/remote-debugging-guide.md
+++ b/docs/remote-debugging-guide.md
@@ -1,6 +1,6 @@
 # Remote Debugging Guide
 
-This guide covers analyzing crash dumps on remote machines using WinDbg's remote debugging protocol.
+This guide covers analyzing crash dumps on remote machines using `remote.exe`.
 
 ## Table of Contents
 
@@ -15,12 +15,14 @@ This guide covers analyzing crash dumps on remote machines using WinDbg's remote
 
 ## Overview
 
-When crash dumps are on a secured cloud VM that you can't copy files from, Atlas can connect remotely using WinDbg's debug server protocol (dbgsrv).
+When crash dumps are on a secured cloud VM that you can't copy files from, Atlas can connect remotely using Microsoft's `remote.exe` utility.
 
 **Key benefits:**
 - Analyze multi-GB dumps without downloading them
 - Keep sensitive data in the secured environment
 - Use standard Windows debugging infrastructure
+- **Persistent sessions** - server stays up for multiple queries
+- **Multiple clients** can connect to the same session
 
 ---
 
@@ -30,19 +32,19 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                        Debug VM (VM2)                                    │
 │  ┌─────────────────┐    ┌────────────────────────────────────────────┐  │
-│  │ C:\dumps\       │    │  cdb -server tcp:port=5005 -z dump.dmp     │  │
+│  │ C:\dumps\       │    │  remote.exe /s "cdb -z dump.dmp" Session   │  │
 │  │ app.dmp         │◀───│  (part of Debugging Tools for Windows)     │  │
-│  │ crash.dmp       │    │  Loads dump and listens for connections    │  │
+│  │ crash.dmp       │    │  Loads dump and exposes named session      │  │
 │  └─────────────────┘    └─────────────────────────────────────────────┘ │
 │                                      ▲                                   │
 └──────────────────────────────────────┼───────────────────────────────────┘
-                                       │ TCP (WinDbg protocol)
-                                       │
+                                       │ SMB (port 445)
+                                       │ Named Pipes
 ┌──────────────────────────────────────┼───────────────────────────────────┐
 │                        Developer Machine (mc00)                          │
 │  ┌───────────────────────────────────┴──────────────────────────────────┐│
 │  │  Atlas.Server                                                        ││
-│  │  - Spawns local cdb.exe with -remote connection string               ││
+│  │  - Uses remote.exe /c to connect to named session                    ││
 │  │  - Sends WinDbg commands: !analyze, !dumpheap, lm, k                 ││
 │  │  - Parses text output into structured JSON                           ││
 │  └───────────────────────────────────────────────────────────────────────┘│
@@ -50,13 +52,13 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 │                              │ MCP                                        │
 │  ┌───────────────────────────┴───────────────────────────────────────────┐│
 │  │  VS Code + GitHub Copilot                                             ││
-│  │  "Analyze the crash dump on debug-vm"                                 ││
+│  │  "Analyze the crash on vm2/DumpSession"                               ││
 │  └───────────────────────────────────────────────────────────────────────┘│
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
-> **Note:** The dump is loaded on the server side using `cdb -server`. The client
-> connects and sends commands directly - no need to open the dump from the client.
+> **Note:** Using `remote.exe` instead of `cdb -server` provides persistent
+> sessions that stay alive for multiple queries.
 
 ---
 
@@ -65,132 +67,125 @@ When crash dumps are on a secured cloud VM that you can't copy files from, Atlas
 ### Prerequisites
 
 **On Debug VM (VM2):**
-- Windows SDK / Debugging Tools for Windows (includes cdb.exe)
-- Firewall rule allowing inbound TCP on debug port
+- Windows SDK / Debugging Tools for Windows (includes remote.exe, cdb.exe)
+- Firewall allowing SMB (port 445) from developer machine
 - Dump files accessible locally
 
 **On Developer Machine (mc00):**
-- Windows SDK / Debugging Tools for Windows (includes cdb.exe)
+- Windows SDK / Debugging Tools for Windows (includes remote.exe)
 - Atlas.Server
-- Network access to debug VM's port
-- cdb.exe in PATH (or specify full path)
+- Network access to debug VM (SMB port 445)
+- remote.exe in PATH
 
-### Step 1: Start Debug Server on VM2
+### Step 1: Start Debug Session on VM2
 
-The server must load the dump file and expose it for remote debugging:
+Start a named session with the dump loaded:
 
-Basic (no authentication):
 ```cmd
-cdb -server tcp:port=5005 -z C:\dumps\app.dmp
+remote.exe /s "cdb -z C:\dumps\app.dmp" DumpSession
 ```
 
-With password:
-```cmd
-cdb -server tcp:port=5005,password=YourSecretPassword -z C:\dumps\app.dmp
-```
+This creates a session named "DumpSession" that anyone can connect to.
 
-With SSL encryption:
-```cmd
-cdb -server ssl:port=5005,password=YourSecretPassword -z C:\dumps\app.dmp
-```
-
-> **Important:** The dump file path is specified on the server side with `-z`.
-> The client doesn't need to know the path - the dump is already loaded.
+**Options:**
+- Session name can be anything descriptive (e.g., `CrashAnalysis`, `Issue123`)
+- Multiple sessions can run simultaneously with different names
 
 ### Step 2: Configure Firewall on VM2
 
 ```powershell
-# Allow inbound connections on debug port
-New-NetFirewallRule -DisplayName "WinDbg Remote Debug" `
-    -Direction Inbound -Protocol TCP -LocalPort 5005 `
+# Allow SMB from specific network (required for remote.exe)
+New-NetFirewallRule -DisplayName "Remote Debug (SMB)" `
+    -Direction Inbound -Protocol TCP -LocalPort 445 `
     -Action Allow -RemoteAddress 10.0.0.0/24
 ```
 
 ### Step 3: Verify Connection from mc00
 
 ```cmd
-cdb -remote tcp:server=vm2.corp.net,port=5005,password=YourSecretPassword
+remote.exe /c VM2 DumpSession
 ```
 
-If you get a debugger prompt with dump info, connection is working. Type `q` to disconnect, `qq` to shut down the server.
+If you get a debugger prompt, connection is working. Type `q` to disconnect (session stays alive).
 
 ---
 
 ## Usage
 
+### Connection String Format
+
+Atlas supports these formats:
+- `hostname/session` - e.g., `vm2/DumpSession`
+- `server=hostname,session=name` - e.g., `server=vm2,session=DumpSession`
+
 ### Analyze a Crash
 
 Ask Copilot:
-> "Analyze the crash dump at C:\dumps\app.dmp on debug server tcp:server=vm2,port=5005"
+> "Analyze the crash on vm2/DumpSession"
 
 Or use the tool directly:
 ```json
 {
   "tool": "remote_analyze_crash",
   "arguments": {
-    "connectionString": "tcp:server=vm2.corp.net,port=5005",
-    "dumpPath": "C:\\dumps\\app.dmp",
-    "password": "YourSecretPassword"
+    "connectionString": "vm2/DumpSession"
   }
 }
 ```
 
 ### Get Heap Statistics
 
-> "Show heap stats from the dump on the debug server"
+> "Show heap stats from vm2/DumpSession"
 
 ### Get Stack Trace
 
-> "Show the managed stack trace from the remote dump"
+> "Show the managed stack trace from vm2/DumpSession"
 
 For native code:
-> "Show the native stack trace from C:\dumps\app.dmp on vm2"
+> "Show the native stack trace from vm2/DumpSession"
 
 ### List Modules
 
-> "What modules were loaded in the crashed process on the debug VM?"
+> "What modules were loaded in vm2/DumpSession?"
 
 ### Run Custom Command
 
-> "Run !pe on the remote dump to show the exception"
+> "Run !pe on vm2/DumpSession to show the exception"
 
 ---
 
 ## Security
 
-### Authentication Options
+### Access Control
 
-| Method | Connection String | Security Level |
-|--------|-------------------|----------------|
-| None | `tcp:server=vm2,port=5005` | ⚠️ Not recommended |
-| Password | `tcp:server=vm2,port=5005,password=secret` | Basic |
-| SSL + Password | `ssl:server=vm2,port=5005,password=secret` | Recommended |
-| Named Pipe | `npipe:server=vm2,pipe=DebugPipe` | Uses Windows auth |
+`remote.exe` uses Windows named pipes over SMB (port 445). Access is controlled by:
+- **Network access** to the server via SMB
+- **Windows file sharing permissions** on the machine
+- **Firewall rules** restricting source IPs
 
 ### Best Practices
 
-1. **Use SSL** for encrypted traffic
-2. **Use IP allowlists** on dbgsrv
-3. **Store passwords** in environment variables, not in code
-4. **Rotate passwords** periodically
-5. **Limit firewall rules** to specific source IPs/subnets
-6. **Stop dbgsrv** when not in use
+1. **Restrict SMB access** to specific subnets in firewall rules
+2. **Use VPN or private network** for connections
+3. **Stop the session** when not in use (press `x` in the server console)
+4. **Use descriptive session names** to track active sessions
+5. **Limit who can access** the debug VM via Windows permissions
 
-### Environment Variable for Password
+### Session Management
 
-```powershell
-# Set in environment
-$env:DEBUG_SERVER_PASSWORD = "YourSecretPassword"
+List active sessions on VM2:
+```cmd
+remote.exe /q VM2
 ```
 
-Then use in Atlas without exposing password in chat:
-> "Analyze dump at C:\dumps\app.dmp on tcp:server=vm2,port=5005 using password from environment"
+Stop a session from the server:
+- Press `x` in the remote.exe server window
 
 ---
 
 ## Troubleshooting
 
-### "Failed to start cdb.exe"
+### "Failed to start remote.exe"
 
 **Cause:** Debugging Tools for Windows not installed or not in PATH.
 
@@ -198,43 +193,43 @@ Then use in Atlas without exposing password in chat:
 1. Install Windows SDK with "Debugging Tools" option
 2. Add to PATH: `C:\Program Files (x86)\Windows Kits\10\Debuggers\x64`
 
-### "Failed to connect to debug server"
+### "Failed to connect to session"
 
 **Causes:**
-- dbgsrv not running on target
-- Firewall blocking connection
-- Wrong hostname/port
-- Wrong password
+- Session not running on target
+- Firewall blocking SMB (port 445)
+- Wrong hostname or session name
+- Network connectivity issue
 
 **Fix:**
-1. Verify dbgsrv is running: `tasklist | findstr dbgsrv` on VM2
-2. Check firewall rules on VM2
-3. Test connection: `cdb -remote tcp:server=vm2,port=5005`
+1. Verify session is running: `remote.exe /q VM2` from client
+2. Check firewall allows SMB from your network
+3. Test: `remote.exe /c VM2 SessionName`
 
 ### "Timed out waiting for debugger response"
 
-**Cause:** Debug server is busy or dump is very large.
+**Cause:** Debug session is busy or dump is very large.
 
 **Fix:**
-- Wait longer (large dumps take time to load)
-- Check if dbgsrv is responding
+- Wait longer (large dumps take time to process commands)
+- Check if session is responding via direct `remote.exe /c` connection
 
-### "Cannot open dump file"
+### "Session not found"
 
 **Causes:**
-- Wrong path
-- File doesn't exist
-- Permissions issue
+- Session name typo
+- Session was stopped
+- Wrong server name
 
 **Fix:**
-1. Verify path exists on remote machine
-2. Check file permissions
+1. Query available sessions: `remote.exe /q VM2`
+2. Verify correct session name and server
 
 ---
 
 ## References
 
+- [Remote.exe Tool](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/the-remote-exe-utility)
+- [Starting a Remote.exe Session](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/starting-a-remote-exe-session)
 - [WinDbg Remote Debugging](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/remote-debugging)
-- [DbgSrv Command Line](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/dbgsrv-command-line-options)
-- [Activating a Debugging Server](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/activating-a-debugging-server)
-- [Process Server Examples](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/process-server-examples)
+- [Debugging Tools for Windows](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/)

--- a/scripts/integration-test.ps1
+++ b/scripts/integration-test.ps1
@@ -1,0 +1,108 @@
+# Integration test for remote debug tools
+# Tests against a running remote.exe session
+
+param(
+    [string]$ConnectionString = "localhost/TestSession"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Add debugging tools to PATH
+$env:Path = "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64;$env:Path"
+
+Write-Host "=== Remote Debug Integration Test ===" -ForegroundColor Cyan
+Write-Host "Connection: $ConnectionString" -ForegroundColor Gray
+Write-Host ""
+
+$parts = $ConnectionString -split '/'
+$server = $parts[0]
+$session = $parts[1]
+
+# Helper function to run a command without quitting
+function Invoke-DebugCommand {
+    param([string]$Command)
+    
+    # Start remote.exe client
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = "remote.exe"
+    $psi.Arguments = "/c $server $session"
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    
+    # Wait for initial connection
+    Start-Sleep -Milliseconds 500
+    
+    # Send command
+    $proc.StandardInput.WriteLine($Command)
+    $proc.StandardInput.Flush()
+    
+    # Wait for output
+    Start-Sleep -Milliseconds 1000
+    
+    # Read available output
+    $output = ""
+    while (!$proc.StandardOutput.EndOfStream) {
+        $line = $proc.StandardOutput.ReadLine()
+        $output += "$line`n"
+        if ($line -match "^\d+:\d+>") { break }
+    }
+    
+    # Kill client without sending 'q' - keeps server alive!
+    $proc.Kill()
+    
+    return $output
+}
+
+# Test 1: Connect and run vertarget
+Write-Host "Test 1: Connect and run 'vertarget'..." -ForegroundColor Yellow
+
+$output = Invoke-DebugCommand "vertarget"
+Write-Host ($output | Select-Object -First 15) -ForegroundColor Gray
+
+if ($output -match "Windows|Dump|Debug") {
+    Write-Host "  PASSED - Connected successfully" -ForegroundColor Green
+} else {
+    Write-Host "  FAILED - Could not connect" -ForegroundColor Red
+}
+
+# Verify session still running
+Write-Host ""
+Write-Host "Checking session is still alive..." -ForegroundColor Yellow
+$query = remote.exe /q localhost 2>&1
+if ($query -match "TestSession") {
+    Write-Host "  Session still running!" -ForegroundColor Green
+} else {
+    Write-Host "  Session died!" -ForegroundColor Red
+    exit 1
+}
+
+# Test 2: Run lm (list modules)
+Write-Host ""
+Write-Host "Test 2: Run 'lm' (list modules)..." -ForegroundColor Yellow
+
+$output = Invoke-DebugCommand "lm"
+$moduleLines = ($output -split "`n" | Where-Object { $_ -match "^\s*[0-9a-f]" })
+Write-Host "  Found $($moduleLines.Count) modules" -ForegroundColor Gray
+
+if ($moduleLines.Count -gt 0) {
+    Write-Host "  PASSED" -ForegroundColor Green
+    Write-Host ($moduleLines | Select-Object -First 5) -ForegroundColor Gray
+}
+
+# Verify session STILL running
+Write-Host ""
+Write-Host "Final check - session still alive..." -ForegroundColor Yellow
+$query = remote.exe /q localhost 2>&1
+if ($query -match "TestSession") {
+    Write-Host "  Session still running - SUCCESS!" -ForegroundColor Green
+} else {
+    Write-Host "  Session died!" -ForegroundColor Red
+}
+
+Write-Host ""
+Write-Host "=== Integration Test Complete ===" -ForegroundColor Cyan

--- a/scripts/test-remote-debug.ps1
+++ b/scripts/test-remote-debug.ps1
@@ -1,0 +1,117 @@
+# Remote Debug Integration Test
+# Requires: Debugging Tools for Windows installed (cdb.exe, dbgsrv.exe in PATH)
+
+param(
+    [string]$DumpPath = "$PSScriptRoot\..\test-dump.dmp",
+    [int]$Port = 5005
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== Remote Debug Integration Test ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Check prerequisites
+Write-Host "Checking prerequisites..." -ForegroundColor Yellow
+
+$cdb = Get-Command cdb.exe -ErrorAction SilentlyContinue
+if (-not $cdb) {
+    Write-Host "ERROR: cdb.exe not found in PATH" -ForegroundColor Red
+    Write-Host "Install Windows SDK with 'Debugging Tools for Windows' option" -ForegroundColor Yellow
+    Write-Host "Then add to PATH: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "  cdb.exe: $($cdb.Source)" -ForegroundColor Green
+
+$dbgsrv = Get-Command dbgsrv.exe -ErrorAction SilentlyContinue
+if (-not $dbgsrv) {
+    Write-Host "ERROR: dbgsrv.exe not found in PATH" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  dbgsrv.exe: $($dbgsrv.Source)" -ForegroundColor Green
+
+if (-not (Test-Path $DumpPath)) {
+    Write-Host "ERROR: Dump file not found: $DumpPath" -ForegroundColor Red
+    exit 1
+}
+$DumpPath = Resolve-Path $DumpPath
+Write-Host "  Dump file: $DumpPath" -ForegroundColor Green
+
+# Check if port is available
+$listener = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
+if ($listener) {
+    Write-Host "ERROR: Port $Port is already in use" -ForegroundColor Red
+    exit 1
+}
+Write-Host "  Port $Port: Available" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Starting dbgsrv on localhost:$Port..." -ForegroundColor Yellow
+
+# Start dbgsrv in background
+$dbgsrvProcess = Start-Process -FilePath "dbgsrv.exe" -ArgumentList "-t tcp:port=$Port" -PassThru -WindowStyle Hidden
+
+Start-Sleep -Seconds 2
+
+if ($dbgsrvProcess.HasExited) {
+    Write-Host "ERROR: dbgsrv failed to start" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "  dbgsrv started (PID: $($dbgsrvProcess.Id))" -ForegroundColor Green
+
+try {
+    Write-Host ""
+    Write-Host "Testing connection with cdb..." -ForegroundColor Yellow
+    
+    # Create a script for cdb to run
+    $cdbScript = @"
+.opendump $DumpPath
+!analyze -v
+q
+"@
+    
+    $tempScript = [System.IO.Path]::GetTempFileName()
+    $cdbScript | Out-File -FilePath $tempScript -Encoding ascii
+    
+    $cdbOutput = & cdb.exe -remote "tcp:server=localhost,port=$Port" -cf $tempScript 2>&1
+    $cdbExitCode = $LASTEXITCODE
+    
+    Remove-Item $tempScript -ErrorAction SilentlyContinue
+    
+    if ($cdbExitCode -ne 0) {
+        Write-Host "ERROR: cdb exited with code $cdbExitCode" -ForegroundColor Red
+        Write-Host $cdbOutput
+        exit 1
+    }
+    
+    # Check if we got meaningful output
+    $outputText = $cdbOutput -join "`n"
+    
+    if ($outputText -match "EXCEPTION_CODE|ExceptionCode|BUGCHECK") {
+        Write-Host "  Connection successful!" -ForegroundColor Green
+        Write-Host "  Crash analysis returned data" -ForegroundColor Green
+    } elseif ($outputText -match "error|cannot|failed") {
+        Write-Host "WARNING: Connection worked but analysis may have issues" -ForegroundColor Yellow
+    } else {
+        Write-Host "  Connection successful (no crash data in test dump)" -ForegroundColor Green
+    }
+    
+    Write-Host ""
+    Write-Host "=== Test Passed ===" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "You can now test Atlas remote tools:" -ForegroundColor Yellow
+    Write-Host "  Connection string: tcp:server=localhost,port=$Port" -ForegroundColor White
+    Write-Host "  Dump path: $DumpPath" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Example prompt for Copilot:" -ForegroundColor Yellow
+    Write-Host "  'Analyze the crash dump at $DumpPath on debug server tcp:server=localhost,port=$Port'" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Press Enter to stop dbgsrv and exit..." -ForegroundColor Gray
+    Read-Host
+    
+} finally {
+    Write-Host "Stopping dbgsrv..." -ForegroundColor Yellow
+    Stop-Process -Id $dbgsrvProcess.Id -Force -ErrorAction SilentlyContinue
+    Write-Host "Done." -ForegroundColor Green
+}

--- a/scripts/test-remote-debug.ps1
+++ b/scripts/test-remote-debug.ps1
@@ -1,5 +1,5 @@
 # Remote Debug Integration Test
-# Requires: Debugging Tools for Windows installed (cdb.exe, dbgsrv.exe in PATH)
+# Requires: Debugging Tools for Windows installed (cdb.exe in PATH)
 
 param(
     [string]$DumpPath = "$PSScriptRoot\..\test-dump.dmp",
@@ -23,13 +23,6 @@ if (-not $cdb) {
 }
 Write-Host "  cdb.exe: $($cdb.Source)" -ForegroundColor Green
 
-$dbgsrv = Get-Command dbgsrv.exe -ErrorAction SilentlyContinue
-if (-not $dbgsrv) {
-    Write-Host "ERROR: dbgsrv.exe not found in PATH" -ForegroundColor Red
-    exit 1
-}
-Write-Host "  dbgsrv.exe: $($dbgsrv.Source)" -ForegroundColor Green
-
 if (-not (Test-Path $DumpPath)) {
     Write-Host "ERROR: Dump file not found: $DumpPath" -ForegroundColor Red
     exit 1
@@ -46,28 +39,29 @@ if ($listener) {
 Write-Host "  Port $Port: Available" -ForegroundColor Green
 
 Write-Host ""
-Write-Host "Starting dbgsrv on localhost:$Port..." -ForegroundColor Yellow
+Write-Host "Starting cdb debug server on localhost:$Port with dump loaded..." -ForegroundColor Yellow
 
-# Start dbgsrv in background
-$dbgsrvProcess = Start-Process -FilePath "dbgsrv.exe" -ArgumentList "-t tcp:port=$Port" -PassThru -WindowStyle Hidden
+# Start cdb as debug server with dump already loaded
+# This is the correct architecture: server has the dump, client just connects
+$serverProcess = Start-Process -FilePath "cdb.exe" -ArgumentList "-server tcp:port=$Port -z `"$DumpPath`"" -PassThru -WindowStyle Hidden
 
-Start-Sleep -Seconds 2
+Start-Sleep -Seconds 3
 
-if ($dbgsrvProcess.HasExited) {
-    Write-Host "ERROR: dbgsrv failed to start" -ForegroundColor Red
+if ($serverProcess.HasExited) {
+    Write-Host "ERROR: cdb debug server failed to start" -ForegroundColor Red
     exit 1
 }
 
-Write-Host "  dbgsrv started (PID: $($dbgsrvProcess.Id))" -ForegroundColor Green
+Write-Host "  Debug server started (PID: $($serverProcess.Id))" -ForegroundColor Green
 
 try {
     Write-Host ""
-    Write-Host "Testing connection with cdb..." -ForegroundColor Yellow
+    Write-Host "Testing client connection..." -ForegroundColor Yellow
     
-    # Create a script for cdb to run
+    # Create a script for client cdb to run
     $cdbScript = @"
-.opendump $DumpPath
-!analyze -v
+vertarget
+lm
 q
 "@
     
@@ -79,39 +73,36 @@ q
     
     Remove-Item $tempScript -ErrorAction SilentlyContinue
     
-    if ($cdbExitCode -ne 0) {
-        Write-Host "ERROR: cdb exited with code $cdbExitCode" -ForegroundColor Red
-        Write-Host $cdbOutput
-        exit 1
-    }
-    
     # Check if we got meaningful output
     $outputText = $cdbOutput -join "`n"
     
-    if ($outputText -match "EXCEPTION_CODE|ExceptionCode|BUGCHECK") {
+    if ($outputText -match "Connected to server") {
         Write-Host "  Connection successful!" -ForegroundColor Green
-        Write-Host "  Crash analysis returned data" -ForegroundColor Green
-    } elseif ($outputText -match "error|cannot|failed") {
-        Write-Host "WARNING: Connection worked but analysis may have issues" -ForegroundColor Yellow
     } else {
-        Write-Host "  Connection successful (no crash data in test dump)" -ForegroundColor Green
+        Write-Host "WARNING: Connection might have issues" -ForegroundColor Yellow
+        Write-Host $outputText
+    }
+    
+    if ($outputText -match "Windows|Debug session") {
+        Write-Host "  Dump loaded and accessible!" -ForegroundColor Green
     }
     
     Write-Host ""
     Write-Host "=== Test Passed ===" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "You can now test Atlas remote tools:" -ForegroundColor Yellow
+    Write-Host "The debug server is running. You can now test Atlas remote tools:" -ForegroundColor Yellow
+    Write-Host ""
     Write-Host "  Connection string: tcp:server=localhost,port=$Port" -ForegroundColor White
-    Write-Host "  Dump path: $DumpPath" -ForegroundColor White
+    Write-Host "  (Dump is already loaded on the server)" -ForegroundColor Gray
     Write-Host ""
     Write-Host "Example prompt for Copilot:" -ForegroundColor Yellow
-    Write-Host "  'Analyze the crash dump at $DumpPath on debug server tcp:server=localhost,port=$Port'" -ForegroundColor White
+    Write-Host "  'Analyze the crash on debug server tcp:server=localhost,port=$Port'" -ForegroundColor White
     Write-Host ""
-    Write-Host "Press Enter to stop dbgsrv and exit..." -ForegroundColor Gray
+    Write-Host "Press Enter to stop the debug server and exit..." -ForegroundColor Gray
     Read-Host
     
 } finally {
-    Write-Host "Stopping dbgsrv..." -ForegroundColor Yellow
-    Stop-Process -Id $dbgsrvProcess.Id -Force -ErrorAction SilentlyContinue
+    Write-Host "Stopping debug server..." -ForegroundColor Yellow
+    Stop-Process -Id $serverProcess.Id -Force -ErrorAction SilentlyContinue
     Write-Host "Done." -ForegroundColor Green
 }

--- a/scripts/test-remote-debug.ps1
+++ b/scripts/test-remote-debug.ps1
@@ -1,9 +1,9 @@
 # Remote Debug Integration Test
-# Requires: Debugging Tools for Windows installed (cdb.exe in PATH)
+# Requires: Debugging Tools for Windows installed (remote.exe, cdb.exe in PATH)
 
 param(
     [string]$DumpPath = "$PSScriptRoot\..\test-dump.dmp",
-    [int]$Port = 5005
+    [string]$SessionName = "TestSession"
 )
 
 $ErrorActionPreference = "Stop"
@@ -13,6 +13,15 @@ Write-Host ""
 
 # Check prerequisites
 Write-Host "Checking prerequisites..." -ForegroundColor Yellow
+
+$remote = Get-Command remote.exe -ErrorAction SilentlyContinue
+if (-not $remote) {
+    Write-Host "ERROR: remote.exe not found in PATH" -ForegroundColor Red
+    Write-Host "Install Windows SDK with 'Debugging Tools for Windows' option" -ForegroundColor Yellow
+    Write-Host "Then add to PATH: C:\Program Files (x86)\Windows Kits\10\Debuggers\x64" -ForegroundColor Yellow
+    exit 1
+}
+Write-Host "  remote.exe: $($remote.Source)" -ForegroundColor Green
 
 $cdb = Get-Command cdb.exe -ErrorAction SilentlyContinue
 if (-not $cdb) {
@@ -30,79 +39,65 @@ if (-not (Test-Path $DumpPath)) {
 $DumpPath = Resolve-Path $DumpPath
 Write-Host "  Dump file: $DumpPath" -ForegroundColor Green
 
-# Check if port is available
-$listener = Get-NetTCPConnection -LocalPort $Port -ErrorAction SilentlyContinue
-if ($listener) {
-    Write-Host "ERROR: Port $Port is already in use" -ForegroundColor Red
-    exit 1
-}
-Write-Host "  Port $Port: Available" -ForegroundColor Green
-
 Write-Host ""
-Write-Host "Starting cdb debug server on localhost:$Port with dump loaded..." -ForegroundColor Yellow
+Write-Host "Starting remote.exe session '$SessionName' with dump loaded..." -ForegroundColor Yellow
 
-# Start cdb as debug server with dump already loaded
-# This is the correct architecture: server has the dump, client just connects
-$serverProcess = Start-Process -FilePath "cdb.exe" -ArgumentList "-server tcp:port=$Port -z `"$DumpPath`"" -PassThru -WindowStyle Hidden
+# Start remote.exe as session server with cdb and dump loaded
+# This provides persistent, multi-client access to the dump
+$serverProcess = Start-Process -FilePath "remote.exe" -ArgumentList "/s `"cdb -z $DumpPath`" $SessionName" -PassThru -WindowStyle Hidden
 
 Start-Sleep -Seconds 3
 
 if ($serverProcess.HasExited) {
-    Write-Host "ERROR: cdb debug server failed to start" -ForegroundColor Red
+    Write-Host "ERROR: remote.exe session failed to start" -ForegroundColor Red
     exit 1
 }
 
-Write-Host "  Debug server started (PID: $($serverProcess.Id))" -ForegroundColor Green
+Write-Host "  Session started (PID: $($serverProcess.Id))" -ForegroundColor Green
 
 try {
     Write-Host ""
     Write-Host "Testing client connection..." -ForegroundColor Yellow
     
-    # Create a script for client cdb to run
-    $cdbScript = @"
-vertarget
-lm
-q
-"@
+    # Test connection with a simple command
+    # Use cmd /c with echo to send command and exit
+    $testOutput = cmd /c "echo vertarget | remote.exe /c localhost $SessionName 2>&1"
     
-    $tempScript = [System.IO.Path]::GetTempFileName()
-    $cdbScript | Out-File -FilePath $tempScript -Encoding ascii
+    $outputText = $testOutput -join "`n"
     
-    $cdbOutput = & cdb.exe -remote "tcp:server=localhost,port=$Port" -cf $tempScript 2>&1
-    $cdbExitCode = $LASTEXITCODE
-    
-    Remove-Item $tempScript -ErrorAction SilentlyContinue
-    
-    # Check if we got meaningful output
-    $outputText = $cdbOutput -join "`n"
-    
-    if ($outputText -match "Connected to server") {
+    if ($outputText -match "Windows|Debug session|Dump|Target") {
         Write-Host "  Connection successful!" -ForegroundColor Green
-    } else {
-        Write-Host "WARNING: Connection might have issues" -ForegroundColor Yellow
-        Write-Host $outputText
-    }
-    
-    if ($outputText -match "Windows|Debug session") {
         Write-Host "  Dump loaded and accessible!" -ForegroundColor Green
+    } else {
+        Write-Host "  Testing via query..." -ForegroundColor Yellow
+        $queryOutput = & remote.exe /q localhost 2>&1
+        if ($queryOutput -match $SessionName) {
+            Write-Host "  Session '$SessionName' is running!" -ForegroundColor Green
+        } else {
+            Write-Host "WARNING: Could not verify session" -ForegroundColor Yellow
+            Write-Host $queryOutput
+        }
     }
     
     Write-Host ""
     Write-Host "=== Test Passed ===" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "The debug server is running. You can now test Atlas remote tools:" -ForegroundColor Yellow
+    Write-Host "The remote session is running. You can now test Atlas remote tools:" -ForegroundColor Yellow
     Write-Host ""
-    Write-Host "  Connection string: tcp:server=localhost,port=$Port" -ForegroundColor White
-    Write-Host "  (Dump is already loaded on the server)" -ForegroundColor Gray
+    Write-Host "  Connection string: localhost/$SessionName" -ForegroundColor White
+    Write-Host "  (Dump is already loaded in the session)" -ForegroundColor Gray
     Write-Host ""
     Write-Host "Example prompt for Copilot:" -ForegroundColor Yellow
-    Write-Host "  'Analyze the crash on debug server tcp:server=localhost,port=$Port'" -ForegroundColor White
+    Write-Host "  'Analyze the crash on localhost/$SessionName'" -ForegroundColor White
     Write-Host ""
-    Write-Host "Press Enter to stop the debug server and exit..." -ForegroundColor Gray
+    Write-Host "Or connect manually:" -ForegroundColor Yellow
+    Write-Host "  remote.exe /c localhost $SessionName" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Press Enter to stop the session and exit..." -ForegroundColor Gray
     Read-Host
     
 } finally {
-    Write-Host "Stopping debug server..." -ForegroundColor Yellow
+    Write-Host "Stopping remote session..." -ForegroundColor Yellow
     Stop-Process -Id $serverProcess.Id -Force -ErrorAction SilentlyContinue
     Write-Host "Done." -ForegroundColor Green
 }

--- a/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
+++ b/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace Atlas.Server.Tests;
 
 /// <summary>
-/// Tests for RemoteDebugTools that don't require actual cdb.exe/dbgsrv.
+/// Tests for RemoteDebugTools that don't require actual cdb.exe.
 /// These test error handling and input validation.
 /// </summary>
 public class RemoteDebugToolsTests
@@ -14,8 +14,7 @@ public class RemoteDebugToolsTests
     {
         // This will fail to connect (no server running), but should handle gracefully
         var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999",
-            dumpPath: @"C:\fake\path.dmp");
+            connectionString: "tcp:server=nonexistent.invalid,port=99999");
 
         var json = JsonSerializer.Serialize(result);
         var doc = JsonDocument.Parse(json);
@@ -29,8 +28,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteHeapStats_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteHeapStats(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999",
-            dumpPath: @"C:\fake\path.dmp");
+            connectionString: "tcp:server=nonexistent.invalid,port=99999");
 
         var json = JsonSerializer.Serialize(result);
         var doc = JsonDocument.Parse(json);
@@ -43,7 +41,6 @@ public class RemoteDebugToolsTests
     {
         var result = await RemoteDebugTools.RemoteStackTrace(
             connectionString: "tcp:server=nonexistent.invalid,port=99999",
-            dumpPath: @"C:\fake\path.dmp",
             stackType: "managed");
 
         var json = JsonSerializer.Serialize(result);
@@ -54,8 +51,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteListModules_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteListModules(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999",
-            dumpPath: @"C:\fake\path.dmp");
+            connectionString: "tcp:server=nonexistent.invalid,port=99999");
 
         var json = JsonSerializer.Serialize(result);
         Assert.Contains("error", json);
@@ -66,7 +62,6 @@ public class RemoteDebugToolsTests
     {
         var result = await RemoteDebugTools.RemoteDebugCommand(
             connectionString: "tcp:server=nonexistent.invalid,port=99999",
-            dumpPath: @"C:\fake\path.dmp",
             command: "vertarget");
 
         var json = JsonSerializer.Serialize(result);
@@ -77,8 +72,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteAnalyzeCrash_PasswordIsSanitizedInResponse()
     {
         var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "tcp:server=test,port=5005,password=supersecret",
-            dumpPath: @"C:\fake\path.dmp");
+            connectionString: "tcp:server=test,port=5005,password=supersecret");
 
         var json = JsonSerializer.Serialize(result);
         
@@ -91,8 +85,7 @@ public class RemoteDebugToolsTests
     {
         // Test via the error response which includes sanitized connection string
         var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "ssl:server=myvm,port=5005,password=MySecretPass123",
-            dumpPath: @"C:\test.dmp");
+            connectionString: "ssl:server=myvm,port=5005,password=MySecretPass123");
         
         var json = JsonSerializer.Serialize(result);
         

--- a/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
+++ b/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
@@ -1,0 +1,102 @@
+using Atlas.Server.Tools;
+using System.Text.Json;
+
+namespace Atlas.Server.Tests;
+
+/// <summary>
+/// Tests for RemoteDebugTools that don't require actual cdb.exe/dbgsrv.
+/// These test error handling and input validation.
+/// </summary>
+public class RemoteDebugToolsTests
+{
+    [Fact]
+    public async Task RemoteAnalyzeCrash_WithInvalidConnectionString_ReturnsError()
+    {
+        // This will fail to connect (no server running), but should handle gracefully
+        var result = await RemoteDebugTools.RemoteAnalyzeCrash(
+            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            dumpPath: @"C:\fake\path.dmp");
+
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("error", out _), "Should return error for invalid connection");
+        Assert.True(root.TryGetProperty("suggestion", out _), "Should include helpful suggestion");
+    }
+
+    [Fact]
+    public async Task RemoteHeapStats_WithInvalidConnectionString_ReturnsError()
+    {
+        var result = await RemoteDebugTools.RemoteHeapStats(
+            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            dumpPath: @"C:\fake\path.dmp");
+
+        var json = JsonSerializer.Serialize(result);
+        var doc = JsonDocument.Parse(json);
+        
+        Assert.Contains("error", json);
+    }
+
+    [Fact]
+    public async Task RemoteStackTrace_WithInvalidConnectionString_ReturnsError()
+    {
+        var result = await RemoteDebugTools.RemoteStackTrace(
+            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            dumpPath: @"C:\fake\path.dmp",
+            stackType: "managed");
+
+        var json = JsonSerializer.Serialize(result);
+        Assert.Contains("error", json);
+    }
+
+    [Fact]
+    public async Task RemoteListModules_WithInvalidConnectionString_ReturnsError()
+    {
+        var result = await RemoteDebugTools.RemoteListModules(
+            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            dumpPath: @"C:\fake\path.dmp");
+
+        var json = JsonSerializer.Serialize(result);
+        Assert.Contains("error", json);
+    }
+
+    [Fact]
+    public async Task RemoteDebugCommand_WithInvalidConnectionString_ReturnsError()
+    {
+        var result = await RemoteDebugTools.RemoteDebugCommand(
+            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            dumpPath: @"C:\fake\path.dmp",
+            command: "vertarget");
+
+        var json = JsonSerializer.Serialize(result);
+        Assert.Contains("error", json);
+    }
+
+    [Fact]
+    public async Task RemoteAnalyzeCrash_PasswordIsSanitizedInResponse()
+    {
+        var result = await RemoteDebugTools.RemoteAnalyzeCrash(
+            connectionString: "tcp:server=test,port=5005,password=supersecret",
+            dumpPath: @"C:\fake\path.dmp");
+
+        var json = JsonSerializer.Serialize(result);
+        
+        // Password should be masked in any returned connection string
+        Assert.DoesNotContain("supersecret", json);
+    }
+
+    [Fact]
+    public async Task ConnectionStringSanitization_RemovesPassword()
+    {
+        // Test via the error response which includes sanitized connection string
+        var result = await RemoteDebugTools.RemoteAnalyzeCrash(
+            connectionString: "ssl:server=myvm,port=5005,password=MySecretPass123",
+            dumpPath: @"C:\test.dmp");
+        
+        var json = JsonSerializer.Serialize(result);
+        
+        Assert.DoesNotContain("MySecretPass123", json);
+        Assert.Contains("password=***", json);
+    }
+}

--- a/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
+++ b/src/Atlas.Server.Tests/RemoteDebugToolsTests.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 namespace Atlas.Server.Tests;
 
 /// <summary>
-/// Tests for RemoteDebugTools that don't require actual cdb.exe.
+/// Tests for RemoteDebugTools that don't require actual remote.exe connections.
 /// These test error handling and input validation.
 /// </summary>
 public class RemoteDebugToolsTests
@@ -14,7 +14,7 @@ public class RemoteDebugToolsTests
     {
         // This will fail to connect (no server running), but should handle gracefully
         var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999");
+            connectionString: "nonexistent.invalid/TestSession");
 
         var json = JsonSerializer.Serialize(result);
         var doc = JsonDocument.Parse(json);
@@ -28,7 +28,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteHeapStats_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteHeapStats(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999");
+            connectionString: "nonexistent.invalid/TestSession");
 
         var json = JsonSerializer.Serialize(result);
         var doc = JsonDocument.Parse(json);
@@ -40,7 +40,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteStackTrace_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteStackTrace(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            connectionString: "nonexistent.invalid/TestSession",
             stackType: "managed");
 
         var json = JsonSerializer.Serialize(result);
@@ -51,7 +51,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteListModules_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteListModules(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999");
+            connectionString: "nonexistent.invalid/TestSession");
 
         var json = JsonSerializer.Serialize(result);
         Assert.Contains("error", json);
@@ -61,7 +61,7 @@ public class RemoteDebugToolsTests
     public async Task RemoteDebugCommand_WithInvalidConnectionString_ReturnsError()
     {
         var result = await RemoteDebugTools.RemoteDebugCommand(
-            connectionString: "tcp:server=nonexistent.invalid,port=99999",
+            connectionString: "nonexistent.invalid/TestSession",
             command: "vertarget");
 
         var json = JsonSerializer.Serialize(result);
@@ -69,27 +69,28 @@ public class RemoteDebugToolsTests
     }
 
     [Fact]
-    public async Task RemoteAnalyzeCrash_PasswordIsSanitizedInResponse()
+    public async Task RemoteAnalyzeCrash_WithBadFormat_ReturnsHelpfulSuggestion()
     {
+        // Test with completely invalid format
         var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "tcp:server=test,port=5005,password=supersecret");
+            connectionString: "invalid-no-session");
 
         var json = JsonSerializer.Serialize(result);
         
-        // Password should be masked in any returned connection string
-        Assert.DoesNotContain("supersecret", json);
+        Assert.Contains("error", json);
+        Assert.Contains("suggestion", json);
     }
 
     [Fact]
-    public async Task ConnectionStringSanitization_RemovesPassword()
+    public async Task ConnectionString_SupportsMultipleFormats()
     {
-        // Test via the error response which includes sanitized connection string
-        var result = await RemoteDebugTools.RemoteAnalyzeCrash(
-            connectionString: "ssl:server=myvm,port=5005,password=MySecretPass123");
+        // These should all parse correctly (though fail to connect)
+        // Format: hostname/session
+        var result1 = await RemoteDebugTools.RemoteDebugCommand("vm2/DumpSession", "vertarget");
+        Assert.Contains("error", JsonSerializer.Serialize(result1)); // Fails to connect, not parse
         
-        var json = JsonSerializer.Serialize(result);
-        
-        Assert.DoesNotContain("MySecretPass123", json);
-        Assert.Contains("password=***", json);
+        // Format: server=hostname,session=name
+        var result2 = await RemoteDebugTools.RemoteDebugCommand("server=vm2,session=DumpSession", "vertarget");
+        Assert.Contains("error", JsonSerializer.Serialize(result2));
     }
 }

--- a/src/Atlas.Server.Tests/TestApps/McpToolTest/McpToolTest.csproj
+++ b/src/Atlas.Server.Tests/TestApps/McpToolTest/McpToolTest.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Atlas.Server\Atlas.Server.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Atlas.Server.Tests/TestApps/McpToolTest/Program.cs
+++ b/src/Atlas.Server.Tests/TestApps/McpToolTest/Program.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using Atlas.Server.Tools;
+
+// Test the actual MCP tools against a running remote.exe session
+// Usage: McpToolTest <connectionString>
+// Example: McpToolTest localhost/TestSession
+
+var connectionString = args.Length > 0 ? args[0] : "localhost/TestSession";
+
+Console.WriteLine("=== MCP Tool Integration Test ===");
+Console.WriteLine($"Connection: {connectionString}");
+Console.WriteLine();
+
+var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+
+// Test 1: remote_debug_command with vertarget
+Console.WriteLine("Test 1: remote_debug_command (vertarget)");
+Console.WriteLine("----------------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteDebugCommand(connectionString, "vertarget");
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 2: remote_list_modules
+Console.WriteLine("Test 2: remote_list_modules");
+Console.WriteLine("---------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteListModules(connectionString);
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    // Truncate if too long
+    if (json.Length > 2000)
+        json = json.Substring(0, 2000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 3: remote_analyze_crash
+Console.WriteLine("Test 3: remote_analyze_crash");
+Console.WriteLine("----------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteAnalyzeCrash(connectionString);
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    // Truncate if too long
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 4: remote_heap_stats (!dumpheap -stat)
+Console.WriteLine("Test 4: remote_heap_stats (!dumpheap -stat)");
+Console.WriteLine("-------------------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteHeapStats(connectionString);
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 5: remote_stack_trace (!clrstack)
+Console.WriteLine("Test 5: remote_stack_trace (managed)");
+Console.WriteLine("------------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteStackTrace(connectionString, "managed");
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 6: raw command - !eeheap
+Console.WriteLine("Test 6: remote_debug_command (!eeheap)");
+Console.WriteLine("--------------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteDebugCommand(connectionString, "!eeheap");
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 7: raw command - !threads
+Console.WriteLine("Test 7: remote_debug_command (!threads)");
+Console.WriteLine("---------------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteDebugCommand(connectionString, "!threads");
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+// Test 8: raw command - k (native stack)
+Console.WriteLine("Test 8: remote_debug_command (k)");
+Console.WriteLine("--------------------------------");
+try
+{
+    var result = await RemoteDebugTools.RemoteDebugCommand(connectionString, "k");
+    var json = JsonSerializer.Serialize(result, jsonOptions);
+    
+    if (json.Length > 3000)
+        json = json.Substring(0, 3000) + "\n... (truncated)";
+    
+    Console.WriteLine(json);
+    
+    if (json.Contains("error"))
+        Console.WriteLine("RESULT: FAILED\n");
+    else
+        Console.WriteLine("RESULT: PASSED\n");
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"Exception: {ex.Message}");
+    Console.WriteLine("RESULT: FAILED\n");
+}
+
+Console.WriteLine("=== Test Complete ===");

--- a/src/Atlas.Server.Tests/WinDbgParserTests.cs
+++ b/src/Atlas.Server.Tests/WinDbgParserTests.cs
@@ -1,0 +1,233 @@
+using Atlas.Server.Debugging.Parsers;
+
+namespace Atlas.Server.Tests;
+
+public class WinDbgParserTests
+{
+    #region AnalyzeParser Tests
+
+    [Fact]
+    public void AnalyzeParser_ParsesAccessViolation()
+    {
+        var output = @"
+*******************************************************************************
+*                                                                             *
+*                        Exception Analysis                                   *
+*                                                                             *
+*******************************************************************************
+
+EXCEPTION_CODE: (NTSTATUS) 0xc0000005 - The instruction at 0x%p referenced memory at 0x%p. The memory could not be %s.
+
+FAULTING_IP: 
+MyApp!ProcessData+42
+00007ff6`12345678 488b01          mov     rax,qword ptr [rcx]
+
+EXCEPTION_RECORD:  00000000001234 -- (.exr 0x1234)
+ExceptionAddress: 00007ff612345678 (MyApp!ProcessData+0x42)
+   ExceptionCode: c0000005 (Access violation)
+  ExceptionFlags: 00000000
+
+FAULTING_MODULE: 00007ff6`12340000 MyApp
+
+PROCESS_NAME:  MyApp.exe
+
+MODULE_NAME: MyApp
+
+SYMBOL_NAME:  MyApp!ProcessData+42
+
+IMAGE_NAME:  MyApp.exe
+
+FAILURE_BUCKET_ID:  ACCESS_VIOLATION_c0000005_MyApp.exe!ProcessData
+
+STACK_TEXT:
+00000000`0012f000 00000000`0012f100 MyApp!ProcessData+0x42
+00000000`0012f100 00000000`0012f200 MyApp!Main+0x128
+
+SYMBOL_NAME:  MyApp!ProcessData+42
+";
+
+        var result = AnalyzeParser.Parse(output);
+
+        Assert.Equal("c0000005", result.ExceptionCode?.ToLower());
+        Assert.Equal("Access Violation", result.CrashType);
+        Assert.Contains("MyApp", result.FaultingModule ?? "");
+        Assert.Contains("ProcessData", result.FaultingSymbol ?? "");
+        Assert.Equal("MyApp.exe", result.ProcessName);
+        Assert.True(result.StackFrames.Count > 0);
+    }
+
+    [Fact]
+    public void AnalyzeParser_ParsesDotNetException()
+    {
+        var output = @"
+ExceptionCode: e0434352 (CLR exception)
+ExceptionAddress: 00007ffc12345678
+
+PROCESS_NAME:  dotnet.exe
+
+MODULE_NAME: clr
+
+SYMBOL_NAME:  clr!RaiseException+0x123
+
+FAILURE_BUCKET_ID:  CLR_EXCEPTION_System.NullReferenceException
+";
+
+        var result = AnalyzeParser.Parse(output);
+
+        Assert.Equal("e0434352", result.ExceptionCode?.ToLower());
+        Assert.Equal(".NET CLR Exception", result.CrashType);
+    }
+
+    [Fact]
+    public void AnalyzeParser_ParsesBugCheck()
+    {
+        var output = @"
+BugCheck D1, {0, 2, 0, fffff80012345678}
+
+SYMBOL_NAME:  baddriver!BadFunction+0x10
+
+IMAGE_NAME:  baddriver.sys
+";
+
+        var result = AnalyzeParser.Parse(output);
+
+        Assert.Equal("D1", result.BugCheckCode);
+        Assert.Equal("Kernel Bug Check (BSOD)", result.CrashType);
+    }
+
+    [Fact]
+    public void AnalyzeParser_HandlesEmptyOutput()
+    {
+        var result = AnalyzeParser.Parse("");
+
+        Assert.Equal("Unknown", result.CrashType);
+        Assert.Empty(result.StackFrames);
+    }
+
+    #endregion
+
+    #region HeapStatsParser Tests
+
+    [Fact]
+    public void HeapStatsParser_ParsesStatOutput()
+    {
+        var output = @"
+Statistics:
+              MT    Count    TotalSize Class Name
+00007ff812345678       10         1000 System.String
+00007ff812345679      100        50000 System.Byte[]
+00007ff81234567a     1000       200000 MyApp.Customer
+Total 1110 objects
+";
+
+        var result = HeapStatsParser.Parse(output);
+
+        Assert.Equal(3, result.TypeStats.Count);
+        Assert.Equal(1110, result.TotalObjects);
+        
+        // Should be sorted by size descending
+        Assert.Equal("MyApp.Customer", result.TypeStats[0].TypeName);
+        Assert.Equal(1000, result.TypeStats[0].Count);
+        Assert.Equal(200000, result.TypeStats[0].TotalSize);
+    }
+
+    [Fact]
+    public void HeapStatsParser_HandlesEmptyOutput()
+    {
+        var result = HeapStatsParser.Parse("");
+
+        Assert.Empty(result.TypeStats);
+        Assert.Equal(0, result.TotalObjects);
+    }
+
+    #endregion
+
+    #region ModuleParser Tests
+
+    [Fact]
+    public void ModuleParser_ParsesModuleList()
+    {
+        var output = @"
+start             end                 module name
+00007ff6`12340000 00007ff6`12350000   MyApp      (deferred)
+00007ffc`00000000 00007ffc`00100000   ntdll      (pdb symbols)
+00007ffc`10000000 00007ffc`10200000   kernel32   (deferred)
+";
+
+        var result = ModuleParser.Parse(output);
+
+        Assert.Equal(3, result.Modules.Count);
+        
+        var myApp = result.Modules.FirstOrDefault(m => m.Name == "MyApp");
+        Assert.NotNull(myApp);
+        Assert.Equal("(deferred)", myApp.Status);
+        Assert.True(myApp.Size > 0);
+    }
+
+    [Fact]
+    public void ModuleParser_HandlesEmptyOutput()
+    {
+        var result = ModuleParser.Parse("");
+
+        Assert.Empty(result.Modules);
+    }
+
+    #endregion
+
+    #region StackParser Tests
+
+    [Fact]
+    public void StackParser_ParsesClrStack()
+    {
+        var output = @"
+OS Thread Id: 0x1234 (0)
+        SP               IP               Function
+000000123456789a 0000001234567abc MyApp.Program.Main(System.String[])
+000000123456789b 0000001234567abd MyApp.Processor.Process(MyApp.Data)
+000000123456789c 0000001234567abe System.Threading.Thread.Start()
+";
+
+        var result = StackParser.ParseClrStack(output);
+
+        Assert.Equal("1234", result.ThreadId);
+        Assert.Equal("Managed (.NET)", result.StackType);
+        Assert.Equal(3, result.Frames.Count);
+        
+        var mainFrame = result.Frames[0];
+        Assert.Equal("MyApp.Program", mainFrame.TypeName);
+        Assert.Equal("Main", mainFrame.MethodName);
+    }
+
+    [Fact]
+    public void StackParser_ParsesNativeStack()
+    {
+        var output = @"
+Child-SP          RetAddr           Call Site
+00000000`0012f000 00000000`77654321 ntdll!NtWaitForSingleObject+0x14
+00000000`0012f100 00000000`77654322 kernel32!WaitForSingleObjectEx+0x9c
+00000000`0012f200 00000000`77654323 MyApp!ProcessData+0x42
+";
+
+        var result = StackParser.ParseNativeStack(output);
+
+        Assert.Equal("Native", result.StackType);
+        Assert.Equal(3, result.Frames.Count);
+        
+        var lastFrame = result.Frames[2];
+        Assert.Equal("MyApp", lastFrame.Module);
+        Assert.Equal("ProcessData", lastFrame.MethodName);
+        Assert.Equal("0x42", lastFrame.Offset);
+    }
+
+    [Fact]
+    public void StackParser_HandlesEmptyOutput()
+    {
+        var clrResult = StackParser.ParseClrStack("");
+        var nativeResult = StackParser.ParseNativeStack("");
+
+        Assert.Empty(clrResult.Frames);
+        Assert.Empty(nativeResult.Frames);
+    }
+
+    #endregion
+}

--- a/src/Atlas.Server/Atlas.Server.csproj
+++ b/src/Atlas.Server/Atlas.Server.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
     <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.5.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="*-*" />
     <PackageReference Include="System.Management" Version="10.0.1" />
   </ItemGroup>
 

--- a/src/Atlas.Server/Debugging/DebugSession.cs
+++ b/src/Atlas.Server/Debugging/DebugSession.cs
@@ -1,0 +1,251 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Atlas.Server.Debugging;
+
+/// <summary>
+/// Manages a connection to a WinDbg debug server via cdb.exe.
+/// </summary>
+public sealed class DebugSession : IAsyncDisposable
+{
+    private readonly Process _process;
+    private readonly StringBuilder _outputBuffer = new();
+    private readonly SemaphoreSlim _commandLock = new(1, 1);
+    private readonly TaskCompletionSource _readyTcs = new();
+    private bool _isDisposed;
+
+    private const string PromptPattern = @"\d+:\d+>";  // e.g., "0:000>"
+    private const int DefaultTimeoutMs = 30000;
+
+    private DebugSession(Process process)
+    {
+        _process = process;
+    }
+
+    /// <summary>
+    /// Connect to a remote debug server.
+    /// </summary>
+    /// <param name="connectionString">WinDbg connection string (e.g., "tcp:server=vm2,port=5005")</param>
+    /// <param name="password">Optional password (appended to connection string if provided)</param>
+    /// <param name="cdbPath">Path to cdb.exe (defaults to searching PATH)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public static async Task<DebugSession> ConnectAsync(
+        string connectionString,
+        string? password = null,
+        string? cdbPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        var fullConnectionString = string.IsNullOrEmpty(password)
+            ? connectionString
+            : $"{connectionString},password={password}";
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = cdbPath ?? "cdb.exe",
+            Arguments = $"-remote {fullConnectionString}",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var process = new Process { StartInfo = startInfo };
+        
+        try
+        {
+            process.Start();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start cdb.exe. Ensure Debugging Tools for Windows is installed. Error: {ex.Message}", ex);
+        }
+
+        var session = new DebugSession(process);
+
+        // Wait for initial prompt
+        try
+        {
+            await session.WaitForPromptAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            await session.DisposeAsync();
+            throw new InvalidOperationException(
+                $"Failed to connect to debug server at '{connectionString}'. Error: {ex.Message}", ex);
+        }
+
+        return session;
+    }
+
+    /// <summary>
+    /// Open a dump file on the remote machine.
+    /// </summary>
+    public async Task<string> OpenDumpAsync(string dumpPath, CancellationToken cancellationToken = default)
+    {
+        return await ExecuteCommandAsync($".opendump {dumpPath}", cancellationToken);
+    }
+
+    /// <summary>
+    /// Execute a debugger command and return the output.
+    /// </summary>
+    public async Task<string> ExecuteCommandAsync(string command, CancellationToken cancellationToken = default)
+    {
+        await _commandLock.WaitAsync(cancellationToken);
+        try
+        {
+            ThrowIfDisposed();
+
+            _outputBuffer.Clear();
+
+            await _process.StandardInput.WriteLineAsync(command);
+            await _process.StandardInput.FlushAsync();
+
+            return await ReadUntilPromptAsync(cancellationToken);
+        }
+        finally
+        {
+            _commandLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Execute !analyze -v command.
+    /// </summary>
+    public Task<string> AnalyzeCrashAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("!analyze -v", cancellationToken);
+
+    /// <summary>
+    /// Execute !dumpheap -stat command.
+    /// </summary>
+    public Task<string> DumpHeapStatsAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("!dumpheap -stat", cancellationToken);
+
+    /// <summary>
+    /// Execute !clrstack command for managed stack traces.
+    /// </summary>
+    public Task<string> GetClrStackAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("!clrstack", cancellationToken);
+
+    /// <summary>
+    /// Execute k command for native stack traces.
+    /// </summary>
+    public Task<string> GetNativeStackAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("k", cancellationToken);
+
+    /// <summary>
+    /// Execute lm command to list modules.
+    /// </summary>
+    public Task<string> ListModulesAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("lm", cancellationToken);
+
+    /// <summary>
+    /// Execute !threads command.
+    /// </summary>
+    public Task<string> ListThreadsAsync(CancellationToken cancellationToken = default)
+        => ExecuteCommandAsync("!threads", cancellationToken);
+
+    /// <summary>
+    /// Quit the debug session.
+    /// </summary>
+    public async Task QuitAsync()
+    {
+        if (_isDisposed) return;
+
+        try
+        {
+            await _process.StandardInput.WriteLineAsync("q");
+            await _process.StandardInput.FlushAsync();
+            
+            // Give it a moment to exit gracefully
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            try
+            {
+                await _process.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                _process.Kill();
+            }
+        }
+        catch
+        {
+            // Ignore errors during cleanup
+        }
+    }
+
+    private async Task WaitForPromptAsync(CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(DefaultTimeoutMs);
+
+        await ReadUntilPromptAsync(timeoutCts.Token);
+    }
+
+    private async Task<string> ReadUntilPromptAsync(CancellationToken cancellationToken)
+    {
+        var buffer = new char[4096];
+        var output = new StringBuilder();
+        var promptRegex = new Regex(PromptPattern);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(DefaultTimeoutMs);
+
+        while (!timeoutCts.Token.IsCancellationRequested)
+        {
+            var readTask = _process.StandardOutput.ReadAsync(buffer, 0, buffer.Length);
+            
+            var completedTask = await Task.WhenAny(
+                readTask,
+                Task.Delay(DefaultTimeoutMs, timeoutCts.Token));
+
+            if (completedTask != readTask)
+            {
+                throw new TimeoutException("Timed out waiting for debugger response");
+            }
+
+            var charsRead = await readTask;
+            if (charsRead == 0)
+            {
+                throw new InvalidOperationException("Debug server connection closed unexpectedly");
+            }
+
+            output.Append(buffer, 0, charsRead);
+
+            var currentOutput = output.ToString();
+            if (promptRegex.IsMatch(currentOutput))
+            {
+                // Remove the prompt from output
+                var lines = currentOutput.Split('\n');
+                var resultLines = lines
+                    .Where(l => !promptRegex.IsMatch(l.Trim()))
+                    .ToArray();
+                
+                return string.Join('\n', resultLines).Trim();
+            }
+        }
+
+        throw new OperationCanceledException("Operation was cancelled", cancellationToken);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_isDisposed)
+        {
+            throw new ObjectDisposedException(nameof(DebugSession));
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+
+        await QuitAsync();
+        
+        _process.Dispose();
+        _commandLock.Dispose();
+    }
+}

--- a/src/Atlas.Server/Debugging/DebugSession.cs
+++ b/src/Atlas.Server/Debugging/DebugSession.cs
@@ -5,7 +5,13 @@ using System.Text.RegularExpressions;
 namespace Atlas.Server.Debugging;
 
 /// <summary>
-/// Manages a connection to a WinDbg debug server via cdb.exe.
+/// Manages a connection to a remote debug session via remote.exe.
+/// 
+/// Server setup (on VM2):
+///   remote.exe /s "cdb -z C:\dumps\crash.dmp" DumpSession
+/// 
+/// This class connects as a client using:
+///   remote.exe /c ServerName SessionName
 /// </summary>
 public sealed class DebugSession : IAsyncDisposable
 {
@@ -24,26 +30,81 @@ public sealed class DebugSession : IAsyncDisposable
     }
 
     /// <summary>
-    /// Connect to a remote debug server.
+    /// Connect to a remote debug session via remote.exe using connection string.
+    /// Parses connection string to extract server and session.
+    /// Format: "hostname/sessionname", "hostname sessionname", or "server=hostname,session=name"
     /// </summary>
-    /// <param name="connectionString">WinDbg connection string (e.g., "tcp:server=vm2,port=5005")</param>
-    /// <param name="password">Optional password (appended to connection string if provided)</param>
-    /// <param name="cdbPath">Path to cdb.exe (defaults to searching PATH)</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     public static async Task<DebugSession> ConnectAsync(
         string connectionString,
-        string? password = null,
-        string? cdbPath = null,
+        string? remotePath = null,
         CancellationToken cancellationToken = default)
     {
-        var fullConnectionString = string.IsNullOrEmpty(password)
-            ? connectionString
-            : $"{connectionString},password={password}";
+        // Parse connection string
+        // Supported formats:
+        //   "hostname/sessionname"
+        //   "hostname sessionname" 
+        //   "server=hostname,session=name"
+        
+        string serverName;
+        string sessionName;
 
+        if (connectionString.Contains('='))
+        {
+            // Parse key=value format
+            var parts = connectionString.Split(',');
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var part in parts)
+            {
+                var kv = part.Split('=', 2);
+                if (kv.Length == 2)
+                {
+                    dict[kv[0].Trim()] = kv[1].Trim();
+                }
+            }
+            
+            serverName = dict.GetValueOrDefault("server") ?? 
+                         throw new ArgumentException("Connection string must include 'server=hostname'");
+            sessionName = dict.GetValueOrDefault("session") ?? 
+                          throw new ArgumentException("Connection string must include 'session=name'");
+        }
+        else if (connectionString.Contains('/'))
+        {
+            var parts = connectionString.Split('/', 2);
+            serverName = parts[0].Trim();
+            sessionName = parts[1].Trim();
+        }
+        else if (connectionString.Contains(' '))
+        {
+            var parts = connectionString.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+            serverName = parts[0].Trim();
+            sessionName = parts.Length > 1 ? parts[1].Trim() : throw new ArgumentException("Session name required");
+        }
+        else
+        {
+            throw new ArgumentException(
+                "Invalid connection string format. Use 'hostname/session', 'hostname session', or 'server=hostname,session=name'");
+        }
+
+        return await ConnectWithParamsAsync(serverName, sessionName, remotePath, cancellationToken);
+    }
+
+    /// <summary>
+    /// Connect to a remote debug session via remote.exe with explicit server and session.
+    /// </summary>
+    /// <param name="serverName">Server machine name or IP (e.g., "vm2" or "10.0.0.5")</param>
+    /// <param name="sessionName">Session name specified when starting the server (e.g., "DumpSession")</param>
+    /// <param name="remotePath">Path to remote.exe (defaults to searching PATH)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public static async Task<DebugSession> ConnectWithParamsAsync(
+        string serverName,
+        string sessionName,
+        string? remotePath = null,
+        CancellationToken cancellationToken = default)
+    {
         var startInfo = new ProcessStartInfo
         {
-            FileName = cdbPath ?? "cdb.exe",
-            Arguments = $"-remote {fullConnectionString}",
+            FileName = remotePath ?? "remote.exe",
+            Arguments = $"/c {serverName} {sessionName}",
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -60,7 +121,7 @@ public sealed class DebugSession : IAsyncDisposable
         catch (Exception ex)
         {
             throw new InvalidOperationException(
-                $"Failed to start cdb.exe. Ensure Debugging Tools for Windows is installed. Error: {ex.Message}", ex);
+                $"Failed to start remote.exe. Ensure Debugging Tools for Windows is installed. Error: {ex.Message}", ex);
         }
 
         var session = new DebugSession(process);
@@ -74,18 +135,10 @@ public sealed class DebugSession : IAsyncDisposable
         {
             await session.DisposeAsync();
             throw new InvalidOperationException(
-                $"Failed to connect to debug server at '{connectionString}'. Error: {ex.Message}", ex);
+                $"Failed to connect to debug session '{sessionName}' on '{serverName}'. Error: {ex.Message}", ex);
         }
 
         return session;
-    }
-
-    /// <summary>
-    /// Open a dump file on the remote machine.
-    /// </summary>
-    public async Task<string> OpenDumpAsync(string dumpPath, CancellationToken cancellationToken = default)
-    {
-        return await ExecuteCommandAsync($".opendump {dumpPath}", cancellationToken);
     }
 
     /// <summary>
@@ -148,7 +201,32 @@ public sealed class DebugSession : IAsyncDisposable
         => ExecuteCommandAsync("!threads", cancellationToken);
 
     /// <summary>
-    /// Quit the debug session.
+    /// Disconnect from the debug session without stopping the server.
+    /// For remote.exe, we just kill the client process - the server keeps running.
+    /// </summary>
+    public async Task DisconnectAsync()
+    {
+        if (_isDisposed) return;
+
+        try
+        {
+            // Just kill the remote.exe client - server stays alive
+            if (!_process.HasExited)
+            {
+                _process.Kill();
+                await _process.WaitForExitAsync();
+            }
+        }
+        catch
+        {
+            // Ignore errors during cleanup
+        }
+    }
+
+    /// <summary>
+    /// Quit the debug session AND stop the server.
+    /// Sends 'q' to cdb, which terminates the remote.exe server.
+    /// Use DisconnectAsync() if you want to keep the server running.
     /// </summary>
     public async Task QuitAsync()
     {
@@ -243,7 +321,8 @@ public sealed class DebugSession : IAsyncDisposable
         if (_isDisposed) return;
         _isDisposed = true;
 
-        await QuitAsync();
+        // Disconnect without stopping the server
+        await DisconnectAsync();
         
         _process.Dispose();
         _commandLock.Dispose();

--- a/src/Atlas.Server/Debugging/Parsers/AnalyzeParser.cs
+++ b/src/Atlas.Server/Debugging/Parsers/AnalyzeParser.cs
@@ -1,0 +1,187 @@
+using System.Text.RegularExpressions;
+
+namespace Atlas.Server.Debugging.Parsers;
+
+/// <summary>
+/// Parses the output of !analyze -v command.
+/// </summary>
+public static class AnalyzeParser
+{
+    public static AnalyzeResult Parse(string output)
+    {
+        var result = new AnalyzeResult
+        {
+            RawOutput = output
+        };
+
+        // Extract bug check / exception code
+        var bugCheckMatch = Regex.Match(output, @"BugCheck\s+([A-Fx0-9]+),\s*\{(.+?)\}", RegexOptions.IgnoreCase);
+        if (bugCheckMatch.Success)
+        {
+            result.BugCheckCode = bugCheckMatch.Groups[1].Value;
+            result.BugCheckParameters = bugCheckMatch.Groups[2].Value;
+        }
+
+        // Extract exception code (for user-mode dumps)
+        var exceptionMatch = Regex.Match(output, @"ExceptionCode:\s*([A-Fx0-9]+)(?:\s*\((.+?)\))?", RegexOptions.IgnoreCase);
+        if (exceptionMatch.Success)
+        {
+            result.ExceptionCode = exceptionMatch.Groups[1].Value;
+            result.ExceptionDescription = exceptionMatch.Groups[2].Success ? exceptionMatch.Groups[2].Value : null;
+        }
+
+        // Alternative exception format
+        var exceptionAltMatch = Regex.Match(output, @"EXCEPTION_CODE:\s*\(([A-Z_]+)\)\s*([A-Fx0-9]+)", RegexOptions.IgnoreCase);
+        if (exceptionAltMatch.Success)
+        {
+            result.ExceptionDescription ??= exceptionAltMatch.Groups[1].Value;
+            result.ExceptionCode ??= exceptionAltMatch.Groups[2].Value;
+        }
+
+        // Extract faulting module
+        var moduleMatch = Regex.Match(output, @"(?:FAULTING_MODULE|MODULE_NAME):\s*(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (moduleMatch.Success)
+        {
+            result.FaultingModule = moduleMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract faulting IP/function
+        var faultingIpMatch = Regex.Match(output, @"FAULTING_IP:\s*\r?\n(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (faultingIpMatch.Success)
+        {
+            result.FaultingInstruction = faultingIpMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract symbol name
+        var symbolMatch = Regex.Match(output, @"SYMBOL_NAME:\s*(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (symbolMatch.Success)
+        {
+            result.FaultingSymbol = symbolMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract image name
+        var imageMatch = Regex.Match(output, @"IMAGE_NAME:\s*(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (imageMatch.Success)
+        {
+            result.FaultingImage = imageMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract process name
+        var processMatch = Regex.Match(output, @"PROCESS_NAME:\s*(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (processMatch.Success)
+        {
+            result.ProcessName = processMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract failure bucket
+        var bucketMatch = Regex.Match(output, @"FAILURE_BUCKET_ID:\s*(.+?)(?:\r?\n|$)", RegexOptions.IgnoreCase);
+        if (bucketMatch.Success)
+        {
+            result.FailureBucket = bucketMatch.Groups[1].Value.Trim();
+        }
+
+        // Extract stack trace
+        result.StackFrames = ParseStackTrace(output);
+
+        // Determine crash type
+        result.CrashType = DetermineCrashType(result);
+
+        return result;
+    }
+
+    private static List<StackFrame> ParseStackTrace(string output)
+    {
+        var frames = new List<StackFrame>();
+
+        // Look for STACK_TEXT or similar section
+        var stackSection = Regex.Match(output, @"STACK_TEXT:\s*\r?\n((?:.+\r?\n)+?)(?:\r?\n\r?\n|SYMBOL_NAME)", RegexOptions.IgnoreCase);
+        if (!stackSection.Success)
+        {
+            // Try alternate format
+            stackSection = Regex.Match(output, @"Child-SP\s+RetAddr.*?\r?\n((?:[0-9a-f`]+.+\r?\n)+)", RegexOptions.IgnoreCase);
+        }
+
+        if (stackSection.Success)
+        {
+            var lines = stackSection.Groups[1].Value.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            var frameIndex = 0;
+
+            foreach (var line in lines)
+            {
+                var trimmedLine = line.Trim();
+                if (string.IsNullOrWhiteSpace(trimmedLine)) continue;
+
+                // Parse stack frame: RetAddr Module!Function+Offset
+                var frameMatch = Regex.Match(trimmedLine, @"([0-9a-f`]+)\s+([0-9a-f`]+)\s+(.+)", RegexOptions.IgnoreCase);
+                if (frameMatch.Success)
+                {
+                    var symbolPart = frameMatch.Groups[3].Value.Trim();
+                    var moduleFuncMatch = Regex.Match(symbolPart, @"(.+?)!(.+?)(?:\+(.+))?$");
+
+                    frames.Add(new StackFrame
+                    {
+                        Index = frameIndex++,
+                        ReturnAddress = frameMatch.Groups[2].Value,
+                        Module = moduleFuncMatch.Success ? moduleFuncMatch.Groups[1].Value : null,
+                        Function = moduleFuncMatch.Success ? moduleFuncMatch.Groups[2].Value : symbolPart,
+                        Offset = moduleFuncMatch.Success && moduleFuncMatch.Groups[3].Success 
+                            ? moduleFuncMatch.Groups[3].Value : null
+                    });
+                }
+            }
+        }
+
+        return frames;
+    }
+
+    private static string DetermineCrashType(AnalyzeResult result)
+    {
+        if (!string.IsNullOrEmpty(result.ExceptionCode))
+        {
+            return result.ExceptionCode.ToUpperInvariant() switch
+            {
+                "C0000005" or "0XC0000005" => "Access Violation",
+                "C00000FD" or "0XC00000FD" => "Stack Overflow",
+                "C0000094" or "0XC0000094" => "Integer Divide by Zero",
+                "C0000096" or "0XC0000096" => "Privileged Instruction",
+                "80000003" or "0X80000003" => "Breakpoint",
+                "E0434352" or "0XE0434352" => ".NET CLR Exception",
+                "E06D7363" or "0XE06D7363" => "C++ Exception",
+                _ => "Exception"
+            };
+        }
+
+        if (!string.IsNullOrEmpty(result.BugCheckCode))
+        {
+            return "Kernel Bug Check (BSOD)";
+        }
+
+        return "Unknown";
+    }
+}
+
+public class AnalyzeResult
+{
+    public string? BugCheckCode { get; set; }
+    public string? BugCheckParameters { get; set; }
+    public string? ExceptionCode { get; set; }
+    public string? ExceptionDescription { get; set; }
+    public string? FaultingModule { get; set; }
+    public string? FaultingInstruction { get; set; }
+    public string? FaultingSymbol { get; set; }
+    public string? FaultingImage { get; set; }
+    public string? ProcessName { get; set; }
+    public string? FailureBucket { get; set; }
+    public string CrashType { get; set; } = "Unknown";
+    public List<StackFrame> StackFrames { get; set; } = new();
+    public string RawOutput { get; set; } = "";
+}
+
+public class StackFrame
+{
+    public int Index { get; set; }
+    public string? ReturnAddress { get; set; }
+    public string? Module { get; set; }
+    public string? Function { get; set; }
+    public string? Offset { get; set; }
+}

--- a/src/Atlas.Server/Debugging/Parsers/HeapStatsParser.cs
+++ b/src/Atlas.Server/Debugging/Parsers/HeapStatsParser.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+
+namespace Atlas.Server.Debugging.Parsers;
+
+/// <summary>
+/// Parses the output of !dumpheap -stat command.
+/// </summary>
+public static class HeapStatsParser
+{
+    public static HeapStatsResult Parse(string output)
+    {
+        var result = new HeapStatsResult
+        {
+            RawOutput = output
+        };
+
+        // Parse the statistics table
+        // Format: MT    Count    TotalSize Class Name
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var inStatsSection = false;
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Detect start of stats section
+            if (trimmedLine.Contains("MT") && trimmedLine.Contains("Count") && trimmedLine.Contains("TotalSize"))
+            {
+                inStatsSection = true;
+                continue;
+            }
+
+            // Detect end / total line
+            if (trimmedLine.StartsWith("Total ") || trimmedLine.Contains("objects"))
+            {
+                var totalMatch = Regex.Match(trimmedLine, @"Total\s+(\d+)\s+objects", RegexOptions.IgnoreCase);
+                if (totalMatch.Success)
+                {
+                    result.TotalObjects = long.Parse(totalMatch.Groups[1].Value);
+                }
+                continue;
+            }
+
+            if (!inStatsSection) continue;
+
+            // Parse stat line: 00007ff123456789    1234    56789 System.String
+            var match = Regex.Match(trimmedLine, @"([0-9a-f]+)\s+(\d+)\s+(\d+)\s+(.+)", RegexOptions.IgnoreCase);
+            if (match.Success)
+            {
+                result.TypeStats.Add(new TypeStat
+                {
+                    MethodTable = match.Groups[1].Value,
+                    Count = long.Parse(match.Groups[2].Value),
+                    TotalSize = long.Parse(match.Groups[3].Value),
+                    TypeName = match.Groups[4].Value.Trim()
+                });
+            }
+        }
+
+        // Calculate totals
+        result.TotalObjects = result.TypeStats.Sum(t => t.Count);
+        result.TotalBytes = result.TypeStats.Sum(t => t.TotalSize);
+
+        // Sort by total size descending
+        result.TypeStats = result.TypeStats
+            .OrderByDescending(t => t.TotalSize)
+            .ToList();
+
+        return result;
+    }
+}
+
+public class HeapStatsResult
+{
+    public long TotalObjects { get; set; }
+    public long TotalBytes { get; set; }
+    public List<TypeStat> TypeStats { get; set; } = new();
+    public string RawOutput { get; set; } = "";
+}
+
+public class TypeStat
+{
+    public string MethodTable { get; set; } = "";
+    public long Count { get; set; }
+    public long TotalSize { get; set; }
+    public string TypeName { get; set; } = "";
+}

--- a/src/Atlas.Server/Debugging/Parsers/ModuleParser.cs
+++ b/src/Atlas.Server/Debugging/Parsers/ModuleParser.cs
@@ -1,0 +1,79 @@
+using System.Text.RegularExpressions;
+
+namespace Atlas.Server.Debugging.Parsers;
+
+/// <summary>
+/// Parses the output of lm (list modules) command.
+/// </summary>
+public static class ModuleParser
+{
+    public static ModuleListResult Parse(string output)
+    {
+        var result = new ModuleListResult
+        {
+            RawOutput = output
+        };
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Skip header lines
+            if (trimmedLine.StartsWith("start") || string.IsNullOrWhiteSpace(trimmedLine))
+                continue;
+
+            // Format: start    end        module name
+            // 00007ff6`12340000 00007ff6`12350000   MyApp      (deferred)
+            var match = Regex.Match(trimmedLine, 
+                @"([0-9a-f`]+)\s+([0-9a-f`]+)\s+(\S+)(?:\s+(.+))?", 
+                RegexOptions.IgnoreCase);
+
+            if (match.Success)
+            {
+                var startAddr = match.Groups[1].Value.Replace("`", "");
+                var endAddr = match.Groups[2].Value.Replace("`", "");
+
+                long start = 0, end = 0;
+                try
+                {
+                    start = Convert.ToInt64(startAddr, 16);
+                    end = Convert.ToInt64(endAddr, 16);
+                }
+                catch { }
+
+                result.Modules.Add(new ModuleInfo
+                {
+                    StartAddress = "0x" + startAddr,
+                    EndAddress = "0x" + endAddr,
+                    Name = match.Groups[3].Value,
+                    Status = match.Groups[4].Success ? match.Groups[4].Value.Trim() : null,
+                    Size = end - start
+                });
+            }
+        }
+
+        // Sort by start address
+        result.Modules = result.Modules
+            .OrderBy(m => m.StartAddress)
+            .ToList();
+
+        return result;
+    }
+}
+
+public class ModuleListResult
+{
+    public List<ModuleInfo> Modules { get; set; } = new();
+    public string RawOutput { get; set; } = "";
+}
+
+public class ModuleInfo
+{
+    public string StartAddress { get; set; } = "";
+    public string EndAddress { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string? Status { get; set; }
+    public long Size { get; set; }
+}

--- a/src/Atlas.Server/Debugging/Parsers/StackParser.cs
+++ b/src/Atlas.Server/Debugging/Parsers/StackParser.cs
@@ -1,0 +1,146 @@
+using System.Text.RegularExpressions;
+
+namespace Atlas.Server.Debugging.Parsers;
+
+/// <summary>
+/// Parses the output of stack trace commands (!clrstack, k, etc.)
+/// </summary>
+public static class StackParser
+{
+    /// <summary>
+    /// Parse !clrstack output (managed stack)
+    /// </summary>
+    public static StackTraceResult ParseClrStack(string output)
+    {
+        var result = new StackTraceResult
+        {
+            RawOutput = output,
+            StackType = "Managed (.NET)"
+        };
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var inStack = false;
+        var frameIndex = 0;
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Detect OS Thread Id header
+            var threadMatch = Regex.Match(trimmedLine, @"OS Thread Id:\s*0x([0-9a-f]+)", RegexOptions.IgnoreCase);
+            if (threadMatch.Success)
+            {
+                result.ThreadId = threadMatch.Groups[1].Value;
+                continue;
+            }
+
+            // Detect column header
+            if (trimmedLine.Contains("SP") && trimmedLine.Contains("IP") && trimmedLine.Contains("Function"))
+            {
+                inStack = true;
+                continue;
+            }
+
+            if (!inStack) continue;
+
+            // Parse frame: SP               IP               Function
+            // 000000123456789 0000001234567ab MyApp.Program.Main()
+            var frameMatch = Regex.Match(trimmedLine, @"([0-9a-f]+)\s+([0-9a-f]+)\s+(.+)", RegexOptions.IgnoreCase);
+            if (frameMatch.Success)
+            {
+                var function = frameMatch.Groups[3].Value.Trim();
+                
+                // Try to extract method signature parts
+                var methodMatch = Regex.Match(function, @"(.+?)\.([^.]+)\((.*?)\)");
+                
+                result.Frames.Add(new StackTraceFrame
+                {
+                    Index = frameIndex++,
+                    StackPointer = "0x" + frameMatch.Groups[1].Value,
+                    InstructionPointer = "0x" + frameMatch.Groups[2].Value,
+                    FullName = function,
+                    TypeName = methodMatch.Success ? methodMatch.Groups[1].Value : null,
+                    MethodName = methodMatch.Success ? methodMatch.Groups[2].Value : function,
+                    Parameters = methodMatch.Success ? methodMatch.Groups[3].Value : null
+                });
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parse k/kp/kv output (native stack)
+    /// </summary>
+    public static StackTraceResult ParseNativeStack(string output)
+    {
+        var result = new StackTraceResult
+        {
+            RawOutput = output,
+            StackType = "Native"
+        };
+
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var frameIndex = 0;
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+
+            // Skip header
+            if (trimmedLine.Contains("Child-SP") || trimmedLine.Contains("RetAddr") || 
+                string.IsNullOrWhiteSpace(trimmedLine))
+                continue;
+
+            // Parse: Child-SP          RetAddr           Call Site
+            // 00000000`12345678 00000000`abcdefgh module!function+0x42
+            var frameMatch = Regex.Match(trimmedLine, 
+                @"([0-9a-f`]+)\s+([0-9a-f`]+)\s+(.+)", 
+                RegexOptions.IgnoreCase);
+
+            if (frameMatch.Success)
+            {
+                var callSite = frameMatch.Groups[3].Value.Trim();
+                
+                // Parse module!function+offset
+                var symbolMatch = Regex.Match(callSite, @"(.+?)!(.+?)(?:\+(.+))?$");
+
+                result.Frames.Add(new StackTraceFrame
+                {
+                    Index = frameIndex++,
+                    StackPointer = "0x" + frameMatch.Groups[1].Value.Replace("`", ""),
+                    ReturnAddress = "0x" + frameMatch.Groups[2].Value.Replace("`", ""),
+                    FullName = callSite,
+                    Module = symbolMatch.Success ? symbolMatch.Groups[1].Value : null,
+                    MethodName = symbolMatch.Success ? symbolMatch.Groups[2].Value : callSite,
+                    Offset = symbolMatch.Success && symbolMatch.Groups[3].Success 
+                        ? symbolMatch.Groups[3].Value : null
+                });
+            }
+        }
+
+        return result;
+    }
+}
+
+public class StackTraceResult
+{
+    public string? ThreadId { get; set; }
+    public string StackType { get; set; } = "Unknown";
+    public List<StackTraceFrame> Frames { get; set; } = new();
+    public string RawOutput { get; set; } = "";
+}
+
+public class StackTraceFrame
+{
+    public int Index { get; set; }
+    public string? StackPointer { get; set; }
+    public string? InstructionPointer { get; set; }
+    public string? ReturnAddress { get; set; }
+    public string FullName { get; set; } = "";
+    public string? Module { get; set; }
+    public string? TypeName { get; set; }
+    public string? MethodName { get; set; }
+    public string? Parameters { get; set; }
+    public string? Offset { get; set; }
+}

--- a/src/Atlas.Server/Tools/RemoteDebugTools.cs
+++ b/src/Atlas.Server/Tools/RemoteDebugTools.cs
@@ -1,0 +1,323 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using Atlas.Server.Debugging;
+using Atlas.Server.Debugging.Parsers;
+
+namespace Atlas.Server.Tools;
+
+/// <summary>
+/// MCP tools for remote dump analysis via WinDbg debug server (dbgsrv).
+/// </summary>
+[McpServerToolType]
+public static class RemoteDebugTools
+{
+    [McpServerTool(Name = "remote_analyze_crash")]
+    [Description("Analyze a crash dump on a remote WinDbg debug server. Returns structured crash analysis including exception info, faulting module, and stack trace.")]
+    public static async Task<object> RemoteAnalyzeCrash(
+        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005' or 'ssl:server=vm2,port=5005')")] 
+        string connectionString,
+        [Description("Full path to the dump file on the remote machine (e.g., 'C:\\dumps\\app.dmp')")] 
+        string dumpPath,
+        [Description("Debug server password (if required and not in connection string)")] 
+        string? password = null)
+    {
+        try
+        {
+            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            
+            var openResult = await session.OpenDumpAsync(dumpPath);
+            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase) || 
+                openResult.Contains("cannot", StringComparison.OrdinalIgnoreCase))
+            {
+                return new { error = "Failed to open dump", details = openResult, dumpPath };
+            }
+
+            var analyzeOutput = await session.AnalyzeCrashAsync();
+            var result = AnalyzeParser.Parse(analyzeOutput);
+
+            return new
+            {
+                status = "success",
+                dumpPath,
+                connectionString = SanitizeConnectionString(connectionString),
+                crashType = result.CrashType,
+                exceptionCode = result.ExceptionCode,
+                exceptionDescription = result.ExceptionDescription,
+                bugCheckCode = result.BugCheckCode,
+                faultingModule = result.FaultingModule,
+                faultingSymbol = result.FaultingSymbol,
+                faultingImage = result.FaultingImage,
+                processName = result.ProcessName,
+                failureBucket = result.FailureBucket,
+                stackTrace = result.StackFrames.Take(20).Select(f => new
+                {
+                    frame = f.Index,
+                    module = f.Module,
+                    function = f.Function,
+                    offset = f.Offset
+                }),
+                note = result.StackFrames.Count > 20 
+                    ? $"Showing first 20 of {result.StackFrames.Count} stack frames" 
+                    : null
+            };
+        }
+        catch (Exception ex)
+        {
+            return new 
+            { 
+                error = "Remote analysis failed", 
+                message = ex.Message,
+                connectionString = SanitizeConnectionString(connectionString),
+                suggestion = GetSuggestion(ex)
+            };
+        }
+    }
+
+    [McpServerTool(Name = "remote_heap_stats")]
+    [Description("Get heap statistics from a dump on a remote debug server. Shows object counts and sizes by type.")]
+    public static async Task<object> RemoteHeapStats(
+        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        string connectionString,
+        [Description("Full path to the dump file on the remote machine")] 
+        string dumpPath,
+        [Description("Debug server password (if required)")] 
+        string? password = null,
+        [Description("Number of top types to return (default: 50)")] 
+        int top = 50)
+    {
+        try
+        {
+            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            
+            var openResult = await session.OpenDumpAsync(dumpPath);
+            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                return new { error = "Failed to open dump", details = openResult };
+            }
+
+            var heapOutput = await session.DumpHeapStatsAsync();
+            var result = HeapStatsParser.Parse(heapOutput);
+
+            return new
+            {
+                status = "success",
+                dumpPath,
+                totalObjects = result.TotalObjects,
+                totalBytes = result.TotalBytes,
+                totalMB = Math.Round(result.TotalBytes / 1024.0 / 1024.0, 2),
+                typeCount = result.TypeStats.Count,
+                topTypes = result.TypeStats.Take(top).Select(t => new
+                {
+                    typeName = t.TypeName,
+                    count = t.Count,
+                    totalBytes = t.TotalSize,
+                    totalMB = Math.Round(t.TotalSize / 1024.0 / 1024.0, 2)
+                })
+            };
+        }
+        catch (Exception ex)
+        {
+            return new 
+            { 
+                error = "Remote heap analysis failed", 
+                message = ex.Message,
+                suggestion = GetSuggestion(ex)
+            };
+        }
+    }
+
+    [McpServerTool(Name = "remote_stack_trace")]
+    [Description("Get stack trace from a dump on a remote debug server. Supports both managed (.NET) and native stacks.")]
+    public static async Task<object> RemoteStackTrace(
+        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        string connectionString,
+        [Description("Full path to the dump file on the remote machine")] 
+        string dumpPath,
+        [Description("Stack type: 'managed' for .NET (!clrstack) or 'native' for native (k). Default: managed")] 
+        string stackType = "managed",
+        [Description("Debug server password (if required)")] 
+        string? password = null)
+    {
+        try
+        {
+            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            
+            var openResult = await session.OpenDumpAsync(dumpPath);
+            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                return new { error = "Failed to open dump", details = openResult };
+            }
+
+            string stackOutput;
+            StackTraceResult result;
+
+            if (stackType.Equals("native", StringComparison.OrdinalIgnoreCase))
+            {
+                stackOutput = await session.GetNativeStackAsync();
+                result = StackParser.ParseNativeStack(stackOutput);
+            }
+            else
+            {
+                stackOutput = await session.GetClrStackAsync();
+                result = StackParser.ParseClrStack(stackOutput);
+            }
+
+            return new
+            {
+                status = "success",
+                dumpPath,
+                stackType = result.StackType,
+                threadId = result.ThreadId,
+                frameCount = result.Frames.Count,
+                frames = result.Frames.Select(f => new
+                {
+                    frame = f.Index,
+                    module = f.Module,
+                    type = f.TypeName,
+                    method = f.MethodName,
+                    offset = f.Offset,
+                    fullName = f.FullName
+                })
+            };
+        }
+        catch (Exception ex)
+        {
+            return new 
+            { 
+                error = "Remote stack trace failed", 
+                message = ex.Message,
+                suggestion = GetSuggestion(ex)
+            };
+        }
+    }
+
+    [McpServerTool(Name = "remote_list_modules")]
+    [Description("List loaded modules from a dump on a remote debug server.")]
+    public static async Task<object> RemoteListModules(
+        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        string connectionString,
+        [Description("Full path to the dump file on the remote machine")] 
+        string dumpPath,
+        [Description("Debug server password (if required)")] 
+        string? password = null)
+    {
+        try
+        {
+            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            
+            var openResult = await session.OpenDumpAsync(dumpPath);
+            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                return new { error = "Failed to open dump", details = openResult };
+            }
+
+            var modulesOutput = await session.ListModulesAsync();
+            var result = ModuleParser.Parse(modulesOutput);
+
+            return new
+            {
+                status = "success",
+                dumpPath,
+                moduleCount = result.Modules.Count,
+                modules = result.Modules.Select(m => new
+                {
+                    name = m.Name,
+                    startAddress = m.StartAddress,
+                    size = m.Size,
+                    sizeMB = Math.Round(m.Size / 1024.0 / 1024.0, 2),
+                    status = m.Status
+                })
+            };
+        }
+        catch (Exception ex)
+        {
+            return new 
+            { 
+                error = "Remote module list failed", 
+                message = ex.Message,
+                suggestion = GetSuggestion(ex)
+            };
+        }
+    }
+
+    [McpServerTool(Name = "remote_debug_command")]
+    [Description("Execute an arbitrary WinDbg command on a remote debug server. For advanced users.")]
+    public static async Task<object> RemoteDebugCommand(
+        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        string connectionString,
+        [Description("Full path to the dump file on the remote machine")] 
+        string dumpPath,
+        [Description("WinDbg command to execute (e.g., '!pe', '!threads', 'vertarget')")] 
+        string command,
+        [Description("Debug server password (if required)")] 
+        string? password = null)
+    {
+        try
+        {
+            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            
+            var openResult = await session.OpenDumpAsync(dumpPath);
+            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
+            {
+                return new { error = "Failed to open dump", details = openResult };
+            }
+
+            var output = await session.ExecuteCommandAsync(command);
+
+            return new
+            {
+                status = "success",
+                dumpPath,
+                command,
+                output = TruncateOutput(output, 10000)
+            };
+        }
+        catch (Exception ex)
+        {
+            return new 
+            { 
+                error = "Remote command failed", 
+                message = ex.Message,
+                command,
+                suggestion = GetSuggestion(ex)
+            };
+        }
+    }
+
+    private static string SanitizeConnectionString(string connectionString)
+    {
+        // Remove password from connection string for logging
+        return System.Text.RegularExpressions.Regex.Replace(
+            connectionString, 
+            @"password=[^,\s]+", 
+            "password=***",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    }
+
+    private static string GetSuggestion(Exception ex)
+    {
+        if (ex.Message.Contains("cdb.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Ensure Debugging Tools for Windows is installed (part of Windows SDK). Add cdb.exe to PATH or specify full path.";
+        }
+
+        if (ex.Message.Contains("connect", StringComparison.OrdinalIgnoreCase) || 
+            ex.Message.Contains("remote", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Could not connect to debug server. Verify: (1) dbgsrv is running on the target, (2) connection string is correct, (3) firewall allows the port, (4) password is correct.";
+        }
+
+        if (ex is TimeoutException)
+        {
+            return "Debug server not responding. The server may be busy or the connection may have been lost.";
+        }
+
+        return "Check connection string format and ensure the remote debug server is accessible.";
+    }
+
+    private static string TruncateOutput(string output, int maxLength)
+    {
+        if (output.Length <= maxLength) return output;
+        return output[..maxLength] + $"\n\n... (truncated, {output.Length - maxLength} more characters)";
+    }
+}

--- a/src/Atlas.Server/Tools/RemoteDebugTools.cs
+++ b/src/Atlas.Server/Tools/RemoteDebugTools.cs
@@ -6,24 +6,25 @@ using Atlas.Server.Debugging.Parsers;
 namespace Atlas.Server.Tools;
 
 /// <summary>
-/// MCP tools for remote dump analysis via WinDbg debug server.
-/// The server must be started with the dump already loaded:
-///   cdb -server tcp:port=5005 -z C:\dumps\app.dmp
+/// MCP tools for remote dump analysis via remote.exe.
+/// 
+/// Server setup (on the remote machine):
+///   remote.exe /s "cdb -z C:\dumps\crash.dmp" DumpSession
+/// 
+/// Connection format: "hostname/session" or "server=hostname,session=name"
 /// </summary>
 [McpServerToolType]
 public static class RemoteDebugTools
 {
     [McpServerTool(Name = "remote_analyze_crash")]
-    [Description("Analyze a crash dump on a remote WinDbg debug server. The dump must already be loaded on the server (started with 'cdb -server tcp:port=5005 -z dump.dmp'). Returns structured crash analysis including exception info, faulting module, and stack trace.")]
+    [Description("Analyze a crash dump on a remote debug session. Server must be started with: remote.exe /s \"cdb -z dump.dmp\" SessionName. Returns structured crash analysis including exception info, faulting module, and stack trace.")]
     public static async Task<object> RemoteAnalyzeCrash(
-        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005' or 'ssl:server=vm2,port=5005')")] 
-        string connectionString,
-        [Description("Debug server password (if required)")] 
-        string? password = null)
+        [Description("Connection string: 'hostname/session' or 'server=hostname,session=name' (e.g., 'vm2/DumpSession')")] 
+        string connectionString)
     {
         try
         {
-            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            await using var session = await DebugSession.ConnectAsync(connectionString);
             
             var analyzeOutput = await session.AnalyzeCrashAsync();
             var result = AnalyzeParser.Parse(analyzeOutput);
@@ -31,7 +32,7 @@ public static class RemoteDebugTools
             return new
             {
                 status = "success",
-                connectionString = SanitizeConnectionString(connectionString),
+                connectionString,
                 crashType = result.CrashType,
                 exceptionCode = result.ExceptionCode,
                 exceptionDescription = result.ExceptionDescription,
@@ -58,26 +59,24 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote analysis failed", 
-                message = SanitizePassword(ex.Message),
-                connectionString = SanitizeConnectionString(connectionString),
+                message = ex.Message,
+                connectionString,
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_heap_stats")]
-    [Description("Get heap statistics from a dump on a remote debug server. The dump must already be loaded on the server. Shows object counts and sizes by type.")]
+    [Description("Get heap statistics from a dump on a remote debug session. Shows object counts and sizes by type.")]
     public static async Task<object> RemoteHeapStats(
-        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        [Description("Connection string: 'hostname/session' (e.g., 'vm2/DumpSession')")] 
         string connectionString,
-        [Description("Debug server password (if required)")] 
-        string? password = null,
         [Description("Number of top types to return (default: 50)")] 
         int top = 50)
     {
         try
         {
-            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            await using var session = await DebugSession.ConnectAsync(connectionString);
 
             var heapOutput = await session.DumpHeapStatsAsync();
             var result = HeapStatsParser.Parse(heapOutput);
@@ -103,25 +102,23 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote heap analysis failed", 
-                message = SanitizePassword(ex.Message),
+                message = ex.Message,
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_stack_trace")]
-    [Description("Get stack trace from a dump on a remote debug server. The dump must already be loaded on the server. Supports both managed (.NET) and native stacks.")]
+    [Description("Get stack trace from a dump on a remote debug session. Supports both managed (.NET) and native stacks.")]
     public static async Task<object> RemoteStackTrace(
-        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        [Description("Connection string: 'hostname/session' (e.g., 'vm2/DumpSession')")] 
         string connectionString,
         [Description("Stack type: 'managed' for .NET (!clrstack) or 'native' for native (k). Default: managed")] 
-        string stackType = "managed",
-        [Description("Debug server password (if required)")] 
-        string? password = null)
+        string stackType = "managed")
     {
         try
         {
-            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            await using var session = await DebugSession.ConnectAsync(connectionString);
             
             string stackOutput;
             StackTraceResult result;
@@ -159,23 +156,21 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote stack trace failed", 
-                message = SanitizePassword(ex.Message),
+                message = ex.Message,
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_list_modules")]
-    [Description("List loaded modules from a dump on a remote debug server. The dump must already be loaded on the server.")]
+    [Description("List loaded modules from a dump on a remote debug session.")]
     public static async Task<object> RemoteListModules(
-        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
-        string connectionString,
-        [Description("Debug server password (if required)")] 
-        string? password = null)
+        [Description("Connection string: 'hostname/session' (e.g., 'vm2/DumpSession')")] 
+        string connectionString)
     {
         try
         {
-            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            await using var session = await DebugSession.ConnectAsync(connectionString);
             
             var modulesOutput = await session.ListModulesAsync();
             var result = ModuleParser.Parse(modulesOutput);
@@ -199,25 +194,23 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote module list failed", 
-                message = SanitizePassword(ex.Message),
+                message = ex.Message,
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_debug_command")]
-    [Description("Execute an arbitrary WinDbg command on a remote debug server. The dump must already be loaded on the server. For advanced users.")]
+    [Description("Execute an arbitrary WinDbg command on a remote debug session. For advanced users.")]
     public static async Task<object> RemoteDebugCommand(
-        [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
+        [Description("Connection string: 'hostname/session' (e.g., 'vm2/DumpSession')")] 
         string connectionString,
         [Description("WinDbg command to execute (e.g., '!pe', '!threads', 'vertarget')")] 
-        string command,
-        [Description("Debug server password (if required)")] 
-        string? password = null)
+        string command)
     {
         try
         {
-            await using var session = await DebugSession.ConnectAsync(connectionString, password);
+            await using var session = await DebugSession.ConnectAsync(connectionString);
             
             var output = await session.ExecuteCommandAsync(command);
 
@@ -233,48 +226,38 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote command failed", 
-                message = SanitizePassword(ex.Message),
+                message = ex.Message,
                 command,
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
-    private static string SanitizeConnectionString(string connectionString)
-    {
-        // Remove password from connection string for logging
-        return SanitizePassword(connectionString);
-    }
-
-    private static string SanitizePassword(string text)
-    {
-        // Remove password values from any text (connection strings, error messages, etc.)
-        return System.Text.RegularExpressions.Regex.Replace(
-            text, 
-            @"password=[^,\s\'\""]+", 
-            "password=***",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-    }
-
     private static string GetSuggestion(Exception ex)
     {
-        if (ex.Message.Contains("cdb.exe", StringComparison.OrdinalIgnoreCase))
+        if (ex.Message.Contains("remote.exe", StringComparison.OrdinalIgnoreCase))
         {
-            return "Ensure Debugging Tools for Windows is installed (part of Windows SDK). Add cdb.exe to PATH or specify full path.";
+            return "Ensure Debugging Tools for Windows is installed (part of Windows SDK). Add remote.exe to PATH.";
         }
 
         if (ex.Message.Contains("connect", StringComparison.OrdinalIgnoreCase) || 
-            ex.Message.Contains("remote", StringComparison.OrdinalIgnoreCase))
+            ex.Message.Contains("session", StringComparison.OrdinalIgnoreCase))
         {
-            return "Could not connect to debug server. Verify: (1) cdb -server is running on the target with -z dump.dmp, (2) connection string is correct, (3) firewall allows the port, (4) password is correct if used.";
+            return "Could not connect to debug session. Verify: (1) remote.exe /s \"cdb -z dump.dmp\" SessionName is running on the target, (2) connection string format is 'hostname/session', (3) firewall allows SMB (port 445).";
         }
 
         if (ex is TimeoutException)
         {
-            return "Debug server not responding. The server may be busy or the connection may have been lost.";
+            return "Debug session not responding. The server may be busy or the connection may have been lost.";
         }
 
-        return "Check connection string format and ensure the remote debug server is accessible.";
+        if (ex.Message.Contains("format", StringComparison.OrdinalIgnoreCase) ||
+            ex.Message.Contains("Invalid", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Connection string format: 'hostname/session' (e.g., 'vm2/DumpSession') or 'server=hostname,session=name'.";
+        }
+
+        return "Check connection string format (hostname/session) and ensure the remote debug session is accessible.";
     }
 
     private static string TruncateOutput(string output, int maxLength)

--- a/src/Atlas.Server/Tools/RemoteDebugTools.cs
+++ b/src/Atlas.Server/Tools/RemoteDebugTools.cs
@@ -6,39 +6,31 @@ using Atlas.Server.Debugging.Parsers;
 namespace Atlas.Server.Tools;
 
 /// <summary>
-/// MCP tools for remote dump analysis via WinDbg debug server (dbgsrv).
+/// MCP tools for remote dump analysis via WinDbg debug server.
+/// The server must be started with the dump already loaded:
+///   cdb -server tcp:port=5005 -z C:\dumps\app.dmp
 /// </summary>
 [McpServerToolType]
 public static class RemoteDebugTools
 {
     [McpServerTool(Name = "remote_analyze_crash")]
-    [Description("Analyze a crash dump on a remote WinDbg debug server. Returns structured crash analysis including exception info, faulting module, and stack trace.")]
+    [Description("Analyze a crash dump on a remote WinDbg debug server. The dump must already be loaded on the server (started with 'cdb -server tcp:port=5005 -z dump.dmp'). Returns structured crash analysis including exception info, faulting module, and stack trace.")]
     public static async Task<object> RemoteAnalyzeCrash(
         [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005' or 'ssl:server=vm2,port=5005')")] 
         string connectionString,
-        [Description("Full path to the dump file on the remote machine (e.g., 'C:\\dumps\\app.dmp')")] 
-        string dumpPath,
-        [Description("Debug server password (if required and not in connection string)")] 
+        [Description("Debug server password (if required)")] 
         string? password = null)
     {
         try
         {
             await using var session = await DebugSession.ConnectAsync(connectionString, password);
             
-            var openResult = await session.OpenDumpAsync(dumpPath);
-            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase) || 
-                openResult.Contains("cannot", StringComparison.OrdinalIgnoreCase))
-            {
-                return new { error = "Failed to open dump", details = openResult, dumpPath };
-            }
-
             var analyzeOutput = await session.AnalyzeCrashAsync();
             var result = AnalyzeParser.Parse(analyzeOutput);
 
             return new
             {
                 status = "success",
-                dumpPath,
                 connectionString = SanitizeConnectionString(connectionString),
                 crashType = result.CrashType,
                 exceptionCode = result.ExceptionCode,
@@ -66,7 +58,7 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote analysis failed", 
-                message = ex.Message,
+                message = SanitizePassword(ex.Message),
                 connectionString = SanitizeConnectionString(connectionString),
                 suggestion = GetSuggestion(ex)
             };
@@ -74,12 +66,10 @@ public static class RemoteDebugTools
     }
 
     [McpServerTool(Name = "remote_heap_stats")]
-    [Description("Get heap statistics from a dump on a remote debug server. Shows object counts and sizes by type.")]
+    [Description("Get heap statistics from a dump on a remote debug server. The dump must already be loaded on the server. Shows object counts and sizes by type.")]
     public static async Task<object> RemoteHeapStats(
         [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
         string connectionString,
-        [Description("Full path to the dump file on the remote machine")] 
-        string dumpPath,
         [Description("Debug server password (if required)")] 
         string? password = null,
         [Description("Number of top types to return (default: 50)")] 
@@ -88,12 +78,6 @@ public static class RemoteDebugTools
         try
         {
             await using var session = await DebugSession.ConnectAsync(connectionString, password);
-            
-            var openResult = await session.OpenDumpAsync(dumpPath);
-            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
-            {
-                return new { error = "Failed to open dump", details = openResult };
-            }
 
             var heapOutput = await session.DumpHeapStatsAsync();
             var result = HeapStatsParser.Parse(heapOutput);
@@ -101,7 +85,6 @@ public static class RemoteDebugTools
             return new
             {
                 status = "success",
-                dumpPath,
                 totalObjects = result.TotalObjects,
                 totalBytes = result.TotalBytes,
                 totalMB = Math.Round(result.TotalBytes / 1024.0 / 1024.0, 2),
@@ -120,19 +103,17 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote heap analysis failed", 
-                message = ex.Message,
+                message = SanitizePassword(ex.Message),
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_stack_trace")]
-    [Description("Get stack trace from a dump on a remote debug server. Supports both managed (.NET) and native stacks.")]
+    [Description("Get stack trace from a dump on a remote debug server. The dump must already be loaded on the server. Supports both managed (.NET) and native stacks.")]
     public static async Task<object> RemoteStackTrace(
         [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
         string connectionString,
-        [Description("Full path to the dump file on the remote machine")] 
-        string dumpPath,
         [Description("Stack type: 'managed' for .NET (!clrstack) or 'native' for native (k). Default: managed")] 
         string stackType = "managed",
         [Description("Debug server password (if required)")] 
@@ -142,12 +123,6 @@ public static class RemoteDebugTools
         {
             await using var session = await DebugSession.ConnectAsync(connectionString, password);
             
-            var openResult = await session.OpenDumpAsync(dumpPath);
-            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
-            {
-                return new { error = "Failed to open dump", details = openResult };
-            }
-
             string stackOutput;
             StackTraceResult result;
 
@@ -165,7 +140,6 @@ public static class RemoteDebugTools
             return new
             {
                 status = "success",
-                dumpPath,
                 stackType = result.StackType,
                 threadId = result.ThreadId,
                 frameCount = result.Frames.Count,
@@ -185,19 +159,17 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote stack trace failed", 
-                message = ex.Message,
+                message = SanitizePassword(ex.Message),
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_list_modules")]
-    [Description("List loaded modules from a dump on a remote debug server.")]
+    [Description("List loaded modules from a dump on a remote debug server. The dump must already be loaded on the server.")]
     public static async Task<object> RemoteListModules(
         [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
         string connectionString,
-        [Description("Full path to the dump file on the remote machine")] 
-        string dumpPath,
         [Description("Debug server password (if required)")] 
         string? password = null)
     {
@@ -205,19 +177,12 @@ public static class RemoteDebugTools
         {
             await using var session = await DebugSession.ConnectAsync(connectionString, password);
             
-            var openResult = await session.OpenDumpAsync(dumpPath);
-            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
-            {
-                return new { error = "Failed to open dump", details = openResult };
-            }
-
             var modulesOutput = await session.ListModulesAsync();
             var result = ModuleParser.Parse(modulesOutput);
 
             return new
             {
                 status = "success",
-                dumpPath,
                 moduleCount = result.Modules.Count,
                 modules = result.Modules.Select(m => new
                 {
@@ -234,19 +199,17 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote module list failed", 
-                message = ex.Message,
+                message = SanitizePassword(ex.Message),
                 suggestion = GetSuggestion(ex)
             };
         }
     }
 
     [McpServerTool(Name = "remote_debug_command")]
-    [Description("Execute an arbitrary WinDbg command on a remote debug server. For advanced users.")]
+    [Description("Execute an arbitrary WinDbg command on a remote debug server. The dump must already be loaded on the server. For advanced users.")]
     public static async Task<object> RemoteDebugCommand(
         [Description("WinDbg connection string (e.g., 'tcp:server=vm2,port=5005')")] 
         string connectionString,
-        [Description("Full path to the dump file on the remote machine")] 
-        string dumpPath,
         [Description("WinDbg command to execute (e.g., '!pe', '!threads', 'vertarget')")] 
         string command,
         [Description("Debug server password (if required)")] 
@@ -256,18 +219,11 @@ public static class RemoteDebugTools
         {
             await using var session = await DebugSession.ConnectAsync(connectionString, password);
             
-            var openResult = await session.OpenDumpAsync(dumpPath);
-            if (openResult.Contains("error", StringComparison.OrdinalIgnoreCase))
-            {
-                return new { error = "Failed to open dump", details = openResult };
-            }
-
             var output = await session.ExecuteCommandAsync(command);
 
             return new
             {
                 status = "success",
-                dumpPath,
                 command,
                 output = TruncateOutput(output, 10000)
             };
@@ -277,7 +233,7 @@ public static class RemoteDebugTools
             return new 
             { 
                 error = "Remote command failed", 
-                message = ex.Message,
+                message = SanitizePassword(ex.Message),
                 command,
                 suggestion = GetSuggestion(ex)
             };
@@ -287,9 +243,15 @@ public static class RemoteDebugTools
     private static string SanitizeConnectionString(string connectionString)
     {
         // Remove password from connection string for logging
+        return SanitizePassword(connectionString);
+    }
+
+    private static string SanitizePassword(string text)
+    {
+        // Remove password values from any text (connection strings, error messages, etc.)
         return System.Text.RegularExpressions.Regex.Replace(
-            connectionString, 
-            @"password=[^,\s]+", 
+            text, 
+            @"password=[^,\s\'\""]+", 
             "password=***",
             System.Text.RegularExpressions.RegexOptions.IgnoreCase);
     }
@@ -304,7 +266,7 @@ public static class RemoteDebugTools
         if (ex.Message.Contains("connect", StringComparison.OrdinalIgnoreCase) || 
             ex.Message.Contains("remote", StringComparison.OrdinalIgnoreCase))
         {
-            return "Could not connect to debug server. Verify: (1) dbgsrv is running on the target, (2) connection string is correct, (3) firewall allows the port, (4) password is correct.";
+            return "Could not connect to debug server. Verify: (1) cdb -server is running on the target with -z dump.dmp, (2) connection string is correct, (3) firewall allows the port, (4) password is correct if used.";
         }
 
         if (ex is TimeoutException)


### PR DESCRIPTION
## Summary

Enables analyzing crash dumps on remote VMs using standard WinDbg remote debugging protocol (dbgsrv). Developers can investigate multi-GB dumps on secured cloud VMs without copying large files locally.

## Architecture

```
┌──────────────────────────────────────────────────────────────────┐
│                      Debug VM                                     │
│  ┌─────────────┐    ┌──────────────────────────────────────────┐ │
│  │ C:\dumps\   │    │  dbgsrv.exe (part of Windows SDK)        │ │
│  │ app.dmp     │◀───│  Listens on TCP port for WinDbg protocol │ │
│  └─────────────┘    └───────────────────────────────────────────┘│
│                                      ▲                            │
└──────────────────────────────────────┼────────────────────────────┘
                                       │ WinDbg protocol (TCP)
┌──────────────────────────────────────┼────────────────────────────┐
│                      Developer Machine                            │
│  ┌───────────────────────────────────┴──────────────────────────┐ │
│  │  Atlas.Server                                                │ │
│  │  - Spawns cdb.exe -remote <connection-string>                │ │
│  │  - Sends commands, parses output → structured JSON           │ │
│  └───────────────────────────────────────────────────────────────┘│
│                              ▲                                    │
│                              │ MCP                                │
│  ┌───────────────────────────┴───────────────────────────────────┐│
│  │  VS Code + GitHub Copilot                                     ││
│  └───────────────────────────────────────────────────────────────┘│
└───────────────────────────────────────────────────────────────────┘
```

## New MCP Tools

| Tool | Description |
|------|-------------|
| `remote_analyze_crash` | Run `!analyze -v` on remote dump - structured crash analysis |
| `remote_heap_stats` | Get heap statistics (`!dumpheap -stat`) from remote dump |
| `remote_stack_trace` | Get managed (`!clrstack`) or native (`k`) stack traces |
| `remote_list_modules` | List loaded modules (`lm`) from remote dump |
| `remote_debug_command` | Execute arbitrary WinDbg command |

## Example Usage

**User asks:**
> "Analyze the crash dump at C:\dumps\app.dmp on debug server tcp:server=vm2,port=5005"

**Atlas returns:**
```json
{
  "crashType": "Access Violation",
  "exceptionCode": "c0000005",
  "faultingModule": "MyApp.dll",
  "faultingSymbol": "MyApp!ProcessData+0x42",
  "stackTrace": [
    { "frame": 0, "module": "MyApp", "function": "ProcessData", "offset": "0x42" },
    { "frame": 1, "module": "MyApp", "function": "Main", "offset": "0x128" }
  ]
}
```

## Implementation

### New Files
- `src/Atlas.Server/Debugging/DebugSession.cs` - Manages cdb.exe process lifecycle
- `src/Atlas.Server/Debugging/Parsers/` - Output parsers for WinDbg commands
  - `AnalyzeParser.cs` - Parses `!analyze -v`
  - `HeapStatsParser.cs` - Parses `!dumpheap -stat`
  - `StackParser.cs` - Parses `!clrstack` and `k`
  - `ModuleParser.cs` - Parses `lm`
- `src/Atlas.Server/Tools/RemoteDebugTools.cs` - MCP tool definitions

### Security
Uses standard WinDbg authentication - security team configures dbgsrv with:
- Password authentication
- SSL/TLS encryption
- IP allowlists

Atlas just uses the provided connection string.

## Testing
- 11 new parser tests
- All 55 tests passing

## Documentation
- New [Remote Debugging Guide](docs/remote-debugging-guide.md)
- Setup instructions for debug server
- Security best practices
- Troubleshooting guide

## Prerequisites
- **Debug VM:** Windows SDK (includes dbgsrv.exe)
- **Developer Machine:** Windows SDK (includes cdb.exe), Atlas

## Checklist

- [x] DebugSession class for cdb.exe process management
- [x] Output parsers for WinDbg commands
- [x] MCP tools exposed
- [x] Unit tests (11 new, 55 total passing)
- [x] Documentation
- [x] Build succeeds

Closes #70
